### PR TITLE
Fix overflow during validation on 32-bit machines.

### DIFF
--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -229,7 +229,7 @@ impl MemInstStore {
             }
         }
         // Can't allocate more than 4GB since its a 32-bits machine
-        if sz + new > (1 << 32) / PAGE_SIZE {
+        if sz + new > ((1u64 << 32) / PAGE_SIZE as u64) as usize {
             return None;
         }
         mem.data.resize((sz + new) * PAGE_SIZE, 0);

--- a/runtime/src/valid.rs
+++ b/runtime/src/valid.rs
@@ -498,9 +498,9 @@ fn check_table(table: &ast::Table) -> Option<()> {
 
 fn check_memory(mem: &ast::Memory) -> Option<()> {
     // Can't allocate more than 4GB since its a 32-bits machine
-    let max = (1 << 32) / 65536;
-    if mem.type_.limits.min as usize > max
-        || (mem.type_.limits.max.is_some() && mem.type_.limits.max.unwrap() as usize > max)
+    let max = (1u64 << 32) / 65536;
+    if mem.type_.limits.min as u64 > max
+        || (mem.type_.limits.max.is_some() && mem.type_.limits.max.unwrap() as u64 > max)
     {
         return None;
     }


### PR DESCRIPTION
When testing this on a 32 bit machine, I observed the proc macro panic because of left shift overflow during validation. This PR fix overflow during validation on 32-bit machines.