### PR TITLE
Copy strings directly into WASM memory

### DIFF
--- a/runtime/src/interpreter.rs
+++ b/runtime/src/interpreter.rs
@@ -109,6 +109,16 @@ impl<'a> Interpreter<'a> {
         }
     }
 
+    /// Push a new value onto the stack
+    pub fn push(&mut self, val: Value) {
+        self.stack.push(val)
+    }
+
+    /// Pop a value from the stack
+    pub fn pop(&mut self) -> Option<Value> {
+        self.stack.pop()
+    }
+
     /// Intrepret a single instruction.
     /// This is the main dispatching function of the interpreter.
     fn instr(&mut self, instr: &Instr) -> IntResult {
@@ -758,7 +768,7 @@ impl<'a> Interpreter<'a> {
         let stack_before_call = self.stack.len();
         */
 
-        if let Some(err) = (f_inst.hostcode)(&mut self.stack) {
+        if let Some(err) = (f_inst.hostcode)(self) {
             return Err(Trap {
                 origin: TrapOrigin::HostFunction(err),
             });

--- a/runtime/src/interpreter.rs
+++ b/runtime/src/interpreter.rs
@@ -121,7 +121,7 @@ impl<'a> Interpreter<'a> {
 
     /// Get mutable access to the underlying memory associated with the current stack frame.
     pub fn get_memory_mut(&mut self) -> &mut [u8] {
-        &mut self.mems[self.frame.module().mem_addrs[0]]
+        &mut self.mems[self.frame.module().mem_addrs[0]].data
     }
 
     /// Intrepret a single instruction.

--- a/runtime/src/interpreter.rs
+++ b/runtime/src/interpreter.rs
@@ -119,6 +119,11 @@ impl<'a> Interpreter<'a> {
         self.stack.pop()
     }
 
+    /// Get mutable access to the underlying memory associated with the current stack frame.
+    pub fn get_memory_mut(&mut self) -> &mut [u8] {
+        &mut self.mems[self.frame.module().mem_addrs[0]]
+    }
+
     /// Intrepret a single instruction.
     /// This is the main dispatching function of the interpreter.
     fn instr(&mut self, instr: &Instr) -> IntResult {

--- a/runtime/src/interpreter.rs
+++ b/runtime/src/interpreter.rs
@@ -3,11 +3,14 @@ use crate::ops::{FloatDemoteOp, FloatOp, FloatPromoteOp, IntOp};
 use crate::runtime::*;
 use crate::types;
 use crate::values::Value;
+use std::mem;
 use std::rc::Rc;
 
 /// A struct storing the state of the current interpreted
 pub struct Interpreter<'a> {
     pub stack: Vec<Value>,
+
+    frame: StackFrame,
 
     funcs: &'a FuncInstStore,
     tables: &'a TableInstStore,
@@ -68,6 +71,13 @@ impl StackFrame {
         }
     }
 
+    /// Get the current module.
+    ///
+    /// Panics if run while a module is not active.
+    fn module(&self) -> &ModuleInst {
+        self.module.as_ref().unwrap()
+    }
+
     pub fn push(&self, module: Option<Rc<ModuleInst>>, stack_idx: usize) -> Option<StackFrame> {
         if self.nested_levels == 0 {
             return None;
@@ -91,6 +101,7 @@ impl<'a> Interpreter<'a> {
     ) -> Interpreter<'a> {
         Interpreter {
             stack: Vec::new(),
+            frame: StackFrame::new(None),
             funcs,
             tables,
             globals,
@@ -100,35 +111,34 @@ impl<'a> Interpreter<'a> {
 
     /// Intrepret a single instruction.
     /// This is the main dispatching function of the interpreter.
-    fn instr(&mut self, sframe: &StackFrame, instr: &Instr) -> IntResult {
+    fn instr(&mut self, instr: &Instr) -> IntResult {
         use crate::ast::Instr::*;
 
-        let module = &sframe.module.as_ref().unwrap();
         match *instr {
             Unreachable => self.unreachable(),
             Nop => self.nop(),
-            Block(ref result_type, ref instrs) => self.block(sframe, result_type, instrs),
-            Loop(_, ref instrs) => self.loop_(sframe, instrs),
+            Block(ref result_type, ref instrs) => self.block(result_type, instrs),
+            Loop(_, ref instrs) => self.loop_(instrs),
             If(ref result_type, ref if_instrs, ref else_instrs) => {
-                self.if_(sframe, result_type, if_instrs, else_instrs)
+                self.if_(result_type, if_instrs, else_instrs)
             }
             Br(nesting_levels) => self.branch(nesting_levels),
             BrIf(nesting_levels) => self.branch_cond(nesting_levels),
             BrTable(ref all_levels, default_level) => self.branch_table(all_levels, default_level),
             Return => self.return_(),
-            Call(idx) => self.call(module.func_addrs[idx as usize], sframe),
-            CallIndirect(idx) => self.call_indirect(idx, sframe, module),
+            Call(idx) => self.call(self.frame.module().func_addrs[idx as usize]),
+            CallIndirect(idx) => self.call_indirect(idx),
             Drop_ => self.drop(),
             Select => self.select(),
-            GetLocal(idx) => self.get_local(idx, sframe),
-            SetLocal(idx) => self.set_local(idx, sframe),
-            TeeLocal(idx) => self.tee_local(idx, sframe),
-            GetGlobal(idx) => self.get_global(idx, module),
-            SetGlobal(idx) => self.set_global(idx, module),
-            Load(ref memop) => self.load(memop, module),
-            Store(ref memop) => self.store(memop, module),
-            CurrentMemory => self.current_memory(module),
-            GrowMemory => self.grow_memory(module),
+            GetLocal(idx) => self.get_local(idx),
+            SetLocal(idx) => self.set_local(idx),
+            TeeLocal(idx) => self.tee_local(idx),
+            GetGlobal(idx) => self.get_global(idx),
+            SetGlobal(idx) => self.set_global(idx),
+            Load(ref memop) => self.load(memop),
+            Store(ref memop) => self.store(memop),
+            CurrentMemory => self.current_memory(),
+            GrowMemory => self.grow_memory(),
             Const(c) => self.const_(c),
             IUnary(ref t, ref op) => self.iunary(t, op),
             FUnary(ref t, ref op) => self.funary(t, op),
@@ -154,16 +164,11 @@ impl<'a> Interpreter<'a> {
     }
 
     /// Interpret a block
-    fn block(
-        &mut self,
-        sframe: &StackFrame,
-        result_type: &[types::Value],
-        instrs: &[Instr],
-    ) -> IntResult {
+    fn block(&mut self, result_type: &[types::Value], instrs: &[Instr]) -> IntResult {
         let local_stack_begin = self.stack.len();
 
         for instr in instrs {
-            match self.instr(sframe, instr)? {
+            match self.instr(instr)? {
                 Branch { nesting_levels } => {
                     // If the instruction caused a branch, we need to exit the block early on.
                     // The way to do so depends if the current block is the target of the branch.
@@ -190,12 +195,12 @@ impl<'a> Interpreter<'a> {
     }
 
     /// Interpret a loop
-    fn loop_(&mut self, sframe: &StackFrame, instrs: &[Instr]) -> IntResult {
+    fn loop_(&mut self, instrs: &[Instr]) -> IntResult {
         let local_stack_begin = self.stack.len();
 
         'outer: loop {
             for instr in instrs {
-                let res = self.instr(sframe, instr)?;
+                let res = self.instr(instr)?;
 
                 match res {
                     Branch { nesting_levels } => {
@@ -252,7 +257,6 @@ impl<'a> Interpreter<'a> {
     /// If/Else block (delegate to block)
     fn if_(
         &mut self,
-        sframe: &StackFrame,
         result_type: &[types::Value],
         if_instrs: &[Instr],
         else_instrs: &[Instr],
@@ -263,9 +267,9 @@ impl<'a> Interpreter<'a> {
         };
 
         Ok(if c != 0 {
-            self.block(sframe, result_type, if_instrs)?
+            self.block(result_type, if_instrs)?
         } else {
-            self.block(sframe, result_type, else_instrs)?
+            self.block(result_type, else_instrs)?
         })
     }
 
@@ -684,40 +688,40 @@ impl<'a> Interpreter<'a> {
     }
 
     /// GetGlobal
-    fn get_global(&mut self, idx: Index, module: &ModuleInst) -> IntResult {
+    fn get_global(&mut self, idx: Index) -> IntResult {
         self.stack
-            .push(self.globals[module.global_addrs[idx as usize]].value);
+            .push(self.globals[self.frame.module().global_addrs[idx as usize]].value);
         Ok(Continue)
     }
 
     /// SetGlobal
-    fn set_global(&mut self, idx: Index, module: &ModuleInst) -> IntResult {
+    fn set_global(&mut self, idx: Index) -> IntResult {
         // "Validation ensures that the global is, in fact, marked as mutable."
         let val = self.stack.pop().unwrap();
-        self.globals[module.global_addrs[idx as usize]].value = val;
+        self.globals[self.frame.module().global_addrs[idx as usize]].value = val;
         Ok(Continue)
     }
 
     /// Push local idx on the Stack
-    fn get_local(&mut self, idx: Index, sframe: &StackFrame) -> IntResult {
-        let val = self.stack[sframe.stack_idx + (idx as usize)];
+    fn get_local(&mut self, idx: Index) -> IntResult {
+        let val = self.stack[self.frame.stack_idx + (idx as usize)];
         self.stack.push(val);
         Ok(Continue)
     }
 
     /// Update local idx based on the value poped from the stack
-    fn set_local(&mut self, idx: Index, sframe: &StackFrame) -> IntResult {
-        self.stack[sframe.stack_idx + (idx as usize)] = self.stack.pop().unwrap();
+    fn set_local(&mut self, idx: Index) -> IntResult {
+        self.stack[self.frame.stack_idx + (idx as usize)] = self.stack.pop().unwrap();
         Ok(Continue)
     }
 
     /// Update the local idx without poping the top of the stack
-    fn tee_local(&mut self, idx: Index, sframe: &StackFrame) -> IntResult {
-        self.stack[sframe.stack_idx + (idx as usize)] = *self.stack.last().unwrap();
+    fn tee_local(&mut self, idx: Index) -> IntResult {
+        self.stack[self.frame.stack_idx + (idx as usize)] = *self.stack.last().unwrap();
         Ok(Continue)
     }
 
-    fn call_module(&mut self, f_inst: &ModuleFuncInst, sframe: &StackFrame) -> IntResult {
+    fn call_module(&mut self, f_inst: &ModuleFuncInst) -> IntResult {
         // Push locals
         for l in &f_inst.code.locals {
             match *l {
@@ -730,14 +734,17 @@ impl<'a> Interpreter<'a> {
 
         // Push the frame
         let frame_begin = self.stack.len() - f_inst.type_.args.len() - f_inst.code.locals.len();
-        let new_frame = sframe
+        let new_frame = self
+            .frame
             .push(Some(f_inst.module.clone()), frame_begin)
             .ok_or(Trap {
                 origin: TrapOrigin::StackOverflow,
             })?;
 
         // Execute the function inside a block
-        self.block(&new_frame, &f_inst.type_.result, &f_inst.code.body)?;
+        let old_frame = mem::replace(&mut self.frame, new_frame);
+        self.block(&f_inst.type_.result, &f_inst.code.body)?;
+        self.frame = old_frame;
 
         // Remove locals/args
         let drain_start = frame_begin;
@@ -746,7 +753,7 @@ impl<'a> Interpreter<'a> {
         Ok(Continue)
     }
 
-    fn call_host(&mut self, f_inst: &HostFuncInst, _sframe: &StackFrame) -> IntResult {
+    fn call_host(&mut self, f_inst: &HostFuncInst) -> IntResult {
         /*
         let stack_before_call = self.stack.len();
         */
@@ -786,23 +793,23 @@ impl<'a> Interpreter<'a> {
     }
 
     /// Call a function directly
-    pub fn call(&mut self, f_addr: FuncAddr, sframe: &StackFrame) -> IntResult {
+    pub fn call(&mut self, f_addr: FuncAddr) -> IntResult {
         // Idea: the new stack_idx is the base frame pointer, which point to the
         // first argument of the called function. When calling call, all
         // arguments should already be on the stack (thanks to validation).
         match self.funcs[f_addr] {
-            FuncInst::Module(ref f_inst) => self.call_module(f_inst, sframe)?,
-            FuncInst::Host(ref f_inst) => self.call_host(f_inst, sframe)?,
+            FuncInst::Module(ref f_inst) => self.call_module(f_inst)?,
+            FuncInst::Host(ref f_inst) => self.call_host(f_inst)?,
         };
 
         Ok(Continue)
     }
 
     /// Call a function indirectly
-    fn call_indirect(&mut self, idx: Index, sframe: &StackFrame, module: &ModuleInst) -> IntResult {
+    fn call_indirect(&mut self, idx: Index) -> IntResult {
         // For the MVP, only the table at index 0 exists and is implicitly refered
-        let tab = &self.tables[module.table_addrs[0]];
-        let type_ = &module.types[idx as usize];
+        let tab = &self.tables[self.frame.module().table_addrs[0]];
+        let type_ = &self.frame.module().types[idx as usize];
         let indirect_idx = match self.stack.pop().unwrap() {
             Value::I32(c) => c as usize,
             _ => unreachable!(),
@@ -833,7 +840,7 @@ impl<'a> Interpreter<'a> {
                 origin: TrapOrigin::CallIndirectTypesDiffer,
             });
         }
-        self.call(func_addr, sframe)
+        self.call(func_addr)
     }
 
     /// Return to the caller of the current function
@@ -842,19 +849,20 @@ impl<'a> Interpreter<'a> {
     }
 
     /// Get the size of the current memory
-    fn current_memory(&mut self, module: &ModuleInst) -> IntResult {
-        self.stack
-            .push(Value::I32(self.mems.size(module.mem_addrs[0]) as u32));
+    fn current_memory(&mut self) -> IntResult {
+        self.stack.push(Value::I32(
+            self.mems.size(self.frame.module().mem_addrs[0]) as u32
+        ));
         Ok(Continue)
     }
 
     /// Grow the memory
-    fn grow_memory(&mut self, module: &ModuleInst) -> IntResult {
+    fn grow_memory(&mut self) -> IntResult {
         let new_pages = match self.stack.pop().unwrap() {
             Value::I32(c) => c as usize,
             _ => unreachable!(),
         };
-        if let Some(old_size) = self.mems.grow(module.mem_addrs[0], new_pages) {
+        if let Some(old_size) = self.mems.grow(self.frame.module().mem_addrs[0], new_pages) {
             self.stack.push(Value::I32(old_size as u32));
         } else {
             self.stack.push(Value::from_i32(-1));
@@ -863,11 +871,11 @@ impl<'a> Interpreter<'a> {
     }
 
     /// Load memory (dispatcher)
-    fn load(&mut self, memop: &LoadOp, module: &ModuleInst) -> IntResult {
+    fn load(&mut self, memop: &LoadOp) -> IntResult {
         use crate::types::Value as Tv;
         use crate::types::{Float, Int};
 
-        let mem = &self.mems[module.mem_addrs[0]];
+        let mem = &self.mems[self.frame.module().mem_addrs[0]];
         let offset = match self.stack.pop().unwrap() {
             Value::I32(c) => c as usize + memop.offset as usize,
             _ => unreachable!(),
@@ -932,11 +940,11 @@ impl<'a> Interpreter<'a> {
     }
 
     /// Store memory (dispatcher)
-    fn store(&mut self, memop: &StoreOp, module: &ModuleInst) -> IntResult {
+    fn store(&mut self, memop: &StoreOp) -> IntResult {
         use crate::types::Value as Tv;
         use crate::types::{Float, Int};
 
-        let mem = &mut self.mems[module.mem_addrs[0]];
+        let mem = &mut self.mems[self.frame.module().mem_addrs[0]];
         let c = self.stack.pop().unwrap();
         let offset = match self.stack.pop().unwrap() {
             Value::I32(c) => c as usize + memop.offset as usize,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -210,8 +210,7 @@ pub fn invoke_func(
     );
     int.stack.extend(args);
 
-    let sframe = interpreter::StackFrame::new(None);
-    match int.call(funcaddr, &sframe) {
+    match int.call(funcaddr) {
         Err(Trap {
             origin: TrapOrigin::StackOverflow,
         }) => Err(Error(E::StackOverflow)),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -202,18 +202,16 @@ pub fn invoke_func(
         return Err(Error(E::ArgumentTypeMismatch));
     }
 
-    let mut int = interpreter::Interpreter::new();
-    int.stack.extend(args);
-
-    let sframe = interpreter::StackFrame::new(None);
-    match int.call(
-        funcaddr,
-        &sframe,
+    let mut int = interpreter::Interpreter::new(
         &store.funcs,
         &store.tables,
         &mut store.globals,
         &mut store.mems,
-    ) {
+    );
+    int.stack.extend(args);
+
+    let sframe = interpreter::StackFrame::new(None);
+    match int.call(funcaddr, &sframe) {
         Err(Trap {
             origin: TrapOrigin::StackOverflow,
         }) => Err(Error(E::StackOverflow)),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -11,6 +11,7 @@ pub mod values;
 
 pub use crate::ast::Module;
 pub use crate::error::Error;
+pub use crate::interpreter::Interpreter;
 pub use crate::runtime::{ExternVal, HostFunc};
 pub use crate::types::Extern;
 pub use crate::values::Value;

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::{ast, types, values};
+use crate::{ast, types, values, Interpreter};
 use std::collections::HashMap;
 use std::ops::{Index, IndexMut};
 use std::rc::Rc;
@@ -32,7 +32,7 @@ pub struct GlobalInst {
 }
 
 pub type HostFunctionError = String;
-pub type HostFunc = Box<dyn Fn(&mut Vec<values::Value>) -> Option<HostFunctionError>>;
+pub type HostFunc = Box<dyn Fn(&mut Interpreter) -> Option<HostFunctionError>>;
 
 pub struct HostFuncInst {
     pub type_: types::Func,

--- a/runtime/tests/script/run.rs
+++ b/runtime/tests/script/run.rs
@@ -275,9 +275,9 @@ fn init_spectest(store: &mut Store, registry: &mut Registry) {
 
     fn print(store: &mut Store, args_types: Vec<types::Value>) -> ExternVal {
         let args_len = args_types.len();
-        let func = move |stack: &mut Vec<values::Value>| {
-            for val in &stack[(stack.len() - args_len)..stack.len()] {
-                println!("{:?}", val);
+        let func = move |interp: &mut Interpreter<'_>| {
+            for _ in 0..args_len {
+                println!("{:?}", interp.pop().unwrap())
             }
             None
         };

--- a/src/import.rs
+++ b/src/import.rs
@@ -113,12 +113,10 @@ fn resolve(import: Import, store: &mut Store) -> ExternVal {
         "literal_debug" => Box::new(sym::literal_debug),
         "span_debug" => Box::new(sym::span_debug),
 
-        "watt_string_with_capacity" => Box::new(sym::watt_string_with_capacity),
-        "watt_string_push_char" => Box::new(sym::watt_string_push_char),
+        "watt_string_new" => Box::new(sym::watt_string_new),
         "watt_string_len" => Box::new(sym::watt_string_len),
-        "watt_string_char_at" => Box::new(sym::watt_string_char_at),
-        "watt_bytes_with_capacity" => Box::new(sym::watt_bytes_with_capacity),
-        "watt_bytes_push" => Box::new(sym::watt_bytes_push),
+        "watt_string_read" => Box::new(sym::watt_string_read),
+        "watt_bytes_new" => Box::new(sym::watt_bytes_new),
         "watt_print_panic" => Box::new(sym::watt_print_panic),
 
         _ => unreachable!("unresolved import: {:?}", name),

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -1,5 +1,5 @@
 use crate::data::Data;
-use crate::watt::Value;
+use crate::watt::{Interpreter, Value};
 use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 use std::char;
 use std::cmp::Ordering;
@@ -23,32 +23,32 @@ const ORDERING_GREATER: u32 = 2;
 
 // args: []
 // result: [Int(I32)]
-pub fn token_stream_new(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_new(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
         let stream = d.tokenstream.push(TokenStream::new());
-        stack.push(Value::I32(stream));
+        interp.push(Value::I32(stream));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_stream_is_empty(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_is_empty(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let stream = &d.tokenstream[pop(stack)];
+        let stream = &d.tokenstream[pop(interp)];
         let is_empty = stream.is_empty();
-        stack.push(Value::I32(is_empty as u32));
+        interp.push(Value::I32(is_empty as u32));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_stream_from_str(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_from_str(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let string = &d.string[pop(stack)];
+        let string = &d.string[pop(interp)];
         let result = TokenStream::from_str(string);
-        stack.push(Value::I32(match result {
+        interp.push(Value::I32(match result {
             Ok(stream) => d.tokenstream.push(stream),
             Err(_error) => SENTINEL,
         }));
@@ -58,21 +58,21 @@ pub fn token_stream_from_str(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_stream_into_iter(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_into_iter(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let stream = &d.tokenstream[pop(stack)];
+        let stream = &d.tokenstream[pop(interp)];
         let iter = stream.clone().into_iter();
-        stack.push(Value::I32(d.intoiter.push(iter)));
+        interp.push(Value::I32(d.intoiter.push(iter)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_stream_iter_next(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_iter_next(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let iter = &mut d.intoiter[pop(stack)];
-        stack.push(Value::I32(match iter.next() {
+        let iter = &mut d.intoiter[pop(interp)];
+        interp.push(Value::I32(match iter.next() {
             Some(token) => d.tokentree.push(token),
             None => SENTINEL,
         }));
@@ -82,54 +82,54 @@ pub fn token_stream_iter_next(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_stream_from_group(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_from_group(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let group = &d.group[pop(stack)];
+        let group = &d.group[pop(interp)];
         let tree = TokenTree::Group(group.clone());
-        stack.push(Value::I32(d.tokenstream.push(TokenStream::from(tree))));
+        interp.push(Value::I32(d.tokenstream.push(TokenStream::from(tree))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_stream_from_ident(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_from_ident(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let ident = &d.ident[pop(stack)];
+        let ident = &d.ident[pop(interp)];
         let tree = TokenTree::Ident(ident.clone());
-        stack.push(Value::I32(d.tokenstream.push(TokenStream::from(tree))));
+        interp.push(Value::I32(d.tokenstream.push(TokenStream::from(tree))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_stream_from_punct(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_from_punct(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let punct = &d.punct[pop(stack)];
+        let punct = &d.punct[pop(interp)];
         let tree = TokenTree::Punct(punct.clone());
-        stack.push(Value::I32(d.tokenstream.push(TokenStream::from(tree))));
+        interp.push(Value::I32(d.tokenstream.push(TokenStream::from(tree))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_stream_from_literal(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_from_literal(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let literal = &d.literal[pop(stack)];
+        let literal = &d.literal[pop(interp)];
         let tree = TokenTree::Literal(literal.clone());
-        stack.push(Value::I32(d.tokenstream.push(TokenStream::from(tree))));
+        interp.push(Value::I32(d.tokenstream.push(TokenStream::from(tree))));
         None
     })
 }
 
 // args: [Int(I32), Int(I32)]
 // result: []
-pub fn token_stream_push_group(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_push_group(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let group = &d.group[pop(stack)];
-        let stream = &mut d.tokenstream[pop(stack)];
+        let group = &d.group[pop(interp)];
+        let stream = &mut d.tokenstream[pop(interp)];
         stream.extend(once(TokenTree::Group(group.clone())));
         None
     })
@@ -137,10 +137,10 @@ pub fn token_stream_push_group(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32), Int(I32)]
 // result: []
-pub fn token_stream_push_ident(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_push_ident(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let ident = &d.ident[pop(stack)];
-        let stream = &mut d.tokenstream[pop(stack)];
+        let ident = &d.ident[pop(interp)];
+        let stream = &mut d.tokenstream[pop(interp)];
         stream.extend(once(TokenTree::Ident(ident.clone())));
         None
     })
@@ -148,10 +148,10 @@ pub fn token_stream_push_ident(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32), Int(I32)]
 // result: []
-pub fn token_stream_push_punct(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_push_punct(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let punct = &d.punct[pop(stack)];
-        let stream = &mut d.tokenstream[pop(stack)];
+        let punct = &d.punct[pop(interp)];
+        let stream = &mut d.tokenstream[pop(interp)];
         stream.extend(once(TokenTree::Punct(punct.clone())));
         None
     })
@@ -159,10 +159,10 @@ pub fn token_stream_push_punct(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32), Int(I32)]
 // result: []
-pub fn token_stream_push_literal(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_push_literal(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let literal = &d.literal[pop(stack)];
-        let stream = &mut d.tokenstream[pop(stack)];
+        let literal = &d.literal[pop(interp)];
+        let stream = &mut d.tokenstream[pop(interp)];
         stream.extend(once(TokenTree::Literal(literal.clone())));
         None
     })
@@ -170,10 +170,10 @@ pub fn token_stream_push_literal(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32), Int(I32)]
 // result: []
-pub fn token_stream_extend(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_extend(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let next = d.tokenstream[pop(stack)].clone();
-        let stream = &mut d.tokenstream[pop(stack)];
+        let next = d.tokenstream[pop(interp)].clone();
+        let stream = &mut d.tokenstream[pop(interp)];
         stream.extend(next);
         None
     })
@@ -181,10 +181,10 @@ pub fn token_stream_extend(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_tree_kind(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_tree_kind(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let token = &d.tokentree[pop(stack)];
-        stack.push(Value::I32(match token {
+        let token = &d.tokentree[pop(interp)];
+        interp.push(Value::I32(match token {
             TokenTree::Group(_) => TOKEN_GROUP,
             TokenTree::Ident(_) => TOKEN_IDENT,
             TokenTree::Punct(_) => TOKEN_PUNCT,
@@ -196,75 +196,75 @@ pub fn token_tree_kind(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_tree_unwrap_group(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_tree_unwrap_group(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let token = &d.tokentree[pop(stack)];
+        let token = &d.tokentree[pop(interp)];
         let group = match token {
             TokenTree::Group(group) => group,
             _ => unreachable!(),
         };
-        stack.push(Value::I32(d.group.push(group.clone())));
+        interp.push(Value::I32(d.group.push(group.clone())));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_tree_unwrap_ident(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_tree_unwrap_ident(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let token = &d.tokentree[pop(stack)];
+        let token = &d.tokentree[pop(interp)];
         let ident = match token {
             TokenTree::Ident(ident) => ident,
             _ => unreachable!(),
         };
-        stack.push(Value::I32(d.ident.push(ident.clone())));
+        interp.push(Value::I32(d.ident.push(ident.clone())));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_tree_unwrap_punct(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_tree_unwrap_punct(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let token = &d.tokentree[pop(stack)];
+        let token = &d.tokentree[pop(interp)];
         let punct = match token {
             TokenTree::Punct(punct) => punct,
             _ => unreachable!(),
         };
-        stack.push(Value::I32(d.punct.push(punct.clone())));
+        interp.push(Value::I32(d.punct.push(punct.clone())));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_tree_unwrap_literal(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_tree_unwrap_literal(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let token = &d.tokentree[pop(stack)];
+        let token = &d.tokentree[pop(interp)];
         let literal = match token {
             TokenTree::Literal(literal) => literal,
             _ => unreachable!(),
         };
-        stack.push(Value::I32(d.literal.push(literal.clone())));
+        interp.push(Value::I32(d.literal.push(literal.clone())));
         None
     })
 }
 
 // args: []
 // result: [Int(I32)]
-pub fn span_call_site(stack: &mut Vec<Value>) -> Option<String> {
+pub fn span_call_site(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        stack.push(Value::I32(d.span.push(Span::call_site())));
+        interp.push(Value::I32(d.span.push(Span::call_site())));
         None
     })
 }
 
 // args: [Int(I32), Int(I32)]
 // result: [Int(I32)]
-pub fn group_new(stack: &mut Vec<Value>) -> Option<String> {
+pub fn group_new(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let stream = &d.tokenstream[pop(stack)];
-        let delimiter = pop(stack);
+        let stream = &d.tokenstream[pop(interp)];
+        let delimiter = pop(interp);
         let delimiter = if delimiter == DELIMITER_PARENTHESIS {
             Delimiter::Parenthesis
         } else if delimiter == DELIMITER_BRACE {
@@ -277,17 +277,17 @@ pub fn group_new(stack: &mut Vec<Value>) -> Option<String> {
             unreachable!()
         };
         let group = Group::new(delimiter, stream.clone());
-        stack.push(Value::I32(d.group.push(group)));
+        interp.push(Value::I32(d.group.push(group)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn group_delimiter(stack: &mut Vec<Value>) -> Option<String> {
+pub fn group_delimiter(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let group = &d.group[pop(stack)];
-        stack.push(Value::I32(match group.delimiter() {
+        let group = &d.group[pop(interp)];
+        interp.push(Value::I32(match group.delimiter() {
             Delimiter::Parenthesis => DELIMITER_PARENTHESIS,
             Delimiter::Brace => DELIMITER_BRACE,
             Delimiter::Bracket => DELIMITER_BRACKET,
@@ -299,30 +299,30 @@ pub fn group_delimiter(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn group_stream(stack: &mut Vec<Value>) -> Option<String> {
+pub fn group_stream(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let group = &d.group[pop(stack)];
-        stack.push(Value::I32(d.tokenstream.push(group.stream())));
+        let group = &d.group[pop(interp)];
+        interp.push(Value::I32(d.tokenstream.push(group.stream())));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn group_span(stack: &mut Vec<Value>) -> Option<String> {
+pub fn group_span(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let group = &d.group[pop(stack)];
-        stack.push(Value::I32(d.span.push(group.span())));
+        let group = &d.group[pop(interp)];
+        interp.push(Value::I32(d.span.push(group.span())));
         None
     })
 }
 
 // args: [Int(I32), Int(I32)]
 // result: []
-pub fn group_set_span(stack: &mut Vec<Value>) -> Option<String> {
+pub fn group_set_span(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let span = d.span[pop(stack)];
-        let group = &mut d.group[pop(stack)];
+        let span = d.span[pop(interp)];
+        let group = &mut d.group[pop(interp)];
         group.set_span(span);
         None
     })
@@ -330,10 +330,10 @@ pub fn group_set_span(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32), Int(I32)]
 // result: [Int(I32)]
-pub fn punct_new(stack: &mut Vec<Value>) -> Option<String> {
+pub fn punct_new(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let spacing = pop(stack);
-        let op = pop(stack);
+        let spacing = pop(interp);
+        let op = pop(interp);
         let spacing = if spacing == SPACING_ALONE {
             Spacing::Alone
         } else if spacing == SPACING_JOINT {
@@ -342,27 +342,27 @@ pub fn punct_new(stack: &mut Vec<Value>) -> Option<String> {
             unreachable!()
         };
         let op = char::from_u32(op).unwrap();
-        stack.push(Value::I32(d.punct.push(Punct::new(op, spacing))));
+        interp.push(Value::I32(d.punct.push(Punct::new(op, spacing))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn punct_as_char(stack: &mut Vec<Value>) -> Option<String> {
+pub fn punct_as_char(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let punct = &d.punct[pop(stack)];
-        stack.push(Value::I32(punct.as_char() as u32));
+        let punct = &d.punct[pop(interp)];
+        interp.push(Value::I32(punct.as_char() as u32));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn punct_spacing(stack: &mut Vec<Value>) -> Option<String> {
+pub fn punct_spacing(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let punct = &d.punct[pop(stack)];
-        stack.push(Value::I32(match punct.spacing() {
+        let punct = &d.punct[pop(interp)];
+        interp.push(Value::I32(match punct.spacing() {
             Spacing::Alone => SPACING_ALONE,
             Spacing::Joint => SPACING_JOINT,
         }));
@@ -372,20 +372,20 @@ pub fn punct_spacing(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn punct_span(stack: &mut Vec<Value>) -> Option<String> {
+pub fn punct_span(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let punct = &d.punct[pop(stack)];
-        stack.push(Value::I32(d.span.push(punct.span())));
+        let punct = &d.punct[pop(interp)];
+        interp.push(Value::I32(d.span.push(punct.span())));
         None
     })
 }
 
 // args: [Int(I32), Int(I32)]
 // result: []
-pub fn punct_set_span(stack: &mut Vec<Value>) -> Option<String> {
+pub fn punct_set_span(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let span = d.span[pop(stack)];
-        let punct = &mut d.punct[pop(stack)];
+        let span = d.span[pop(interp)];
+        let punct = &mut d.punct[pop(interp)];
         punct.set_span(span);
         None
     })
@@ -393,31 +393,31 @@ pub fn punct_set_span(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32), Int(I32)]
 // result: [Int(I32)]
-pub fn ident_new(stack: &mut Vec<Value>) -> Option<String> {
+pub fn ident_new(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let span = d.span[pop(stack)];
-        let string = &d.string[pop(stack)];
-        stack.push(Value::I32(d.ident.push(Ident::new(string, span))));
+        let span = d.span[pop(interp)];
+        let string = &d.string[pop(interp)];
+        interp.push(Value::I32(d.ident.push(Ident::new(string, span))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn ident_span(stack: &mut Vec<Value>) -> Option<String> {
+pub fn ident_span(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let ident = &d.ident[pop(stack)];
-        stack.push(Value::I32(d.span.push(ident.span())));
+        let ident = &d.ident[pop(interp)];
+        interp.push(Value::I32(d.span.push(ident.span())));
         None
     })
 }
 
 // args: [Int(I32), Int(I32)]
 // result: []
-pub fn ident_set_span(stack: &mut Vec<Value>) -> Option<String> {
+pub fn ident_set_span(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let span = d.span[pop(stack)];
-        let ident = &mut d.ident[pop(stack)];
+        let span = d.span[pop(interp)];
+        let ident = &mut d.ident[pop(interp)];
         ident.set_span(span);
         None
     })
@@ -425,378 +425,378 @@ pub fn ident_set_span(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32), Int(I32)]
 // result: [Int(I32)]
-pub fn ident_eq(stack: &mut Vec<Value>) -> Option<String> {
+pub fn ident_eq(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let other = &d.ident[pop(stack)];
-        let ident = &d.ident[pop(stack)];
+        let other = &d.ident[pop(interp)];
+        let ident = &d.ident[pop(interp)];
         let eq = ident.to_string() == other.to_string();
-        stack.push(Value::I32(eq as u32));
+        interp.push(Value::I32(eq as u32));
         None
     })
 }
 
 // args: [Int(I32), Int(I32)]
 // result: [Int(I32)]
-pub fn ident_eq_str(stack: &mut Vec<Value>) -> Option<String> {
+pub fn ident_eq_str(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let other = &d.string[pop(stack)];
-        let ident = &d.ident[pop(stack)];
+        let other = &d.string[pop(interp)];
+        let ident = &d.ident[pop(interp)];
         let eq = ident.to_string() == *other;
-        stack.push(Value::I32(eq as u32));
+        interp.push(Value::I32(eq as u32));
         None
     })
 }
 
 // args: [Int(I32), Int(I32)]
 // result: [Int(I32)]
-pub fn ident_cmp(stack: &mut Vec<Value>) -> Option<String> {
+pub fn ident_cmp(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let other = &d.ident[pop(stack)];
-        let ident = &d.ident[pop(stack)];
+        let other = &d.ident[pop(interp)];
+        let ident = &d.ident[pop(interp)];
         let cmp = match ident.to_string().cmp(&other.to_string()) {
             Ordering::Less => ORDERING_LESS,
             Ordering::Equal => ORDERING_EQUAL,
             Ordering::Greater => ORDERING_GREATER,
         };
-        stack.push(Value::I32(cmp));
+        interp.push(Value::I32(cmp));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_u8_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_u8_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as u8;
-        stack.push(Value::I32(d.literal.push(Literal::u8_suffixed(n))));
+        let n = pop(interp) as u8;
+        interp.push(Value::I32(d.literal.push(Literal::u8_suffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_u16_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_u16_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as u16;
-        stack.push(Value::I32(d.literal.push(Literal::u16_suffixed(n))));
+        let n = pop(interp) as u16;
+        interp.push(Value::I32(d.literal.push(Literal::u16_suffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_u32_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_u32_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack);
-        stack.push(Value::I32(d.literal.push(Literal::u32_suffixed(n))));
+        let n = pop(interp);
+        interp.push(Value::I32(d.literal.push(Literal::u32_suffixed(n))));
         None
     })
 }
 
 // args: [Int(I64)]
 // result: [Int(I32)]
-pub fn literal_u64_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_u64_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop64(stack);
-        stack.push(Value::I32(d.literal.push(Literal::u64_suffixed(n))));
+        let n = pop64(interp);
+        interp.push(Value::I32(d.literal.push(Literal::u64_suffixed(n))));
         None
     })
 }
 
 // args: [Int(I64), Int(I64)]
 // result: [Int(I32)]
-pub fn literal_u128_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_u128_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let hi = pop64(stack);
-        let lo = pop64(stack);
+        let hi = pop64(interp);
+        let lo = pop64(interp);
         let n = ((hi as u128) << 64) + lo as u128;
-        stack.push(Value::I32(d.literal.push(Literal::u128_suffixed(n))));
+        interp.push(Value::I32(d.literal.push(Literal::u128_suffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_usize_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_usize_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as usize;
-        stack.push(Value::I32(d.literal.push(Literal::usize_suffixed(n))));
+        let n = pop(interp) as usize;
+        interp.push(Value::I32(d.literal.push(Literal::usize_suffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_i8_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_i8_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as i8;
-        stack.push(Value::I32(d.literal.push(Literal::i8_suffixed(n))));
+        let n = pop(interp) as i8;
+        interp.push(Value::I32(d.literal.push(Literal::i8_suffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_i16_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_i16_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as i16;
-        stack.push(Value::I32(d.literal.push(Literal::i16_suffixed(n))));
+        let n = pop(interp) as i16;
+        interp.push(Value::I32(d.literal.push(Literal::i16_suffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_i32_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_i32_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as i32;
-        stack.push(Value::I32(d.literal.push(Literal::i32_suffixed(n))));
+        let n = pop(interp) as i32;
+        interp.push(Value::I32(d.literal.push(Literal::i32_suffixed(n))));
         None
     })
 }
 
 // args: [Int(I64)]
 // result: [Int(I32)]
-pub fn literal_i64_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_i64_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop64(stack) as i64;
-        stack.push(Value::I32(d.literal.push(Literal::i64_suffixed(n))));
+        let n = pop64(interp) as i64;
+        interp.push(Value::I32(d.literal.push(Literal::i64_suffixed(n))));
         None
     })
 }
 
 // args: [Int(I64), Int(I64)]
 // result: [Int(I32)]
-pub fn literal_i128_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_i128_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let hi = pop64(stack);
-        let lo = pop64(stack);
+        let hi = pop64(interp);
+        let lo = pop64(interp);
         let n = (((hi as u128) << 64) + lo as u128) as i128;
-        stack.push(Value::I32(d.literal.push(Literal::i128_suffixed(n))));
+        interp.push(Value::I32(d.literal.push(Literal::i128_suffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_isize_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_isize_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as isize;
-        stack.push(Value::I32(d.literal.push(Literal::isize_suffixed(n))));
+        let n = pop(interp) as isize;
+        interp.push(Value::I32(d.literal.push(Literal::isize_suffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_u8_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_u8_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as u8;
-        stack.push(Value::I32(d.literal.push(Literal::u8_unsuffixed(n))));
+        let n = pop(interp) as u8;
+        interp.push(Value::I32(d.literal.push(Literal::u8_unsuffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_u16_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_u16_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as u16;
-        stack.push(Value::I32(d.literal.push(Literal::u16_unsuffixed(n))));
+        let n = pop(interp) as u16;
+        interp.push(Value::I32(d.literal.push(Literal::u16_unsuffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_u32_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_u32_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack);
-        stack.push(Value::I32(d.literal.push(Literal::u32_unsuffixed(n))));
+        let n = pop(interp);
+        interp.push(Value::I32(d.literal.push(Literal::u32_unsuffixed(n))));
         None
     })
 }
 
 // args: [Int(I64)]
 // result: [Int(I32)]
-pub fn literal_u64_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_u64_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop64(stack);
-        stack.push(Value::I32(d.literal.push(Literal::u64_unsuffixed(n))));
+        let n = pop64(interp);
+        interp.push(Value::I32(d.literal.push(Literal::u64_unsuffixed(n))));
         None
     })
 }
 
 // args: [Int(I64), Int(I64)]
 // result: [Int(I32)]
-pub fn literal_u128_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_u128_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let hi = pop64(stack);
-        let lo = pop64(stack);
+        let hi = pop64(interp);
+        let lo = pop64(interp);
         let n = ((hi as u128) << 64) + lo as u128;
-        stack.push(Value::I32(d.literal.push(Literal::u128_unsuffixed(n))));
+        interp.push(Value::I32(d.literal.push(Literal::u128_unsuffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_usize_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_usize_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as usize;
-        stack.push(Value::I32(d.literal.push(Literal::usize_unsuffixed(n))));
+        let n = pop(interp) as usize;
+        interp.push(Value::I32(d.literal.push(Literal::usize_unsuffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_i8_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_i8_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as i8;
-        stack.push(Value::I32(d.literal.push(Literal::i8_unsuffixed(n))));
+        let n = pop(interp) as i8;
+        interp.push(Value::I32(d.literal.push(Literal::i8_unsuffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_i16_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_i16_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as i16;
-        stack.push(Value::I32(d.literal.push(Literal::i16_unsuffixed(n))));
+        let n = pop(interp) as i16;
+        interp.push(Value::I32(d.literal.push(Literal::i16_unsuffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_i32_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_i32_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as i32;
-        stack.push(Value::I32(d.literal.push(Literal::i32_unsuffixed(n))));
+        let n = pop(interp) as i32;
+        interp.push(Value::I32(d.literal.push(Literal::i32_unsuffixed(n))));
         None
     })
 }
 
 // args: [Int(I64)]
 // result: [Int(I32)]
-pub fn literal_i64_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_i64_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop64(stack) as i64;
-        stack.push(Value::I32(d.literal.push(Literal::i64_unsuffixed(n))));
+        let n = pop64(interp) as i64;
+        interp.push(Value::I32(d.literal.push(Literal::i64_unsuffixed(n))));
         None
     })
 }
 
 // args: [Int(I64), Int(I64)]
 // result: [Int(I32)]
-pub fn literal_i128_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_i128_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let hi = pop64(stack);
-        let lo = pop64(stack);
+        let hi = pop64(interp);
+        let lo = pop64(interp);
         let n = (((hi as u128) << 64) + lo as u128) as i128;
-        stack.push(Value::I32(d.literal.push(Literal::i128_unsuffixed(n))));
+        interp.push(Value::I32(d.literal.push(Literal::i128_unsuffixed(n))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_isize_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_isize_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let n = pop(stack) as isize;
-        stack.push(Value::I32(d.literal.push(Literal::isize_unsuffixed(n))));
+        let n = pop(interp) as isize;
+        interp.push(Value::I32(d.literal.push(Literal::isize_unsuffixed(n))));
         None
     })
 }
 
 // args: [Int(F64)]
 // result: [Int(I32)]
-pub fn literal_f64_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_f64_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let f = popf64(stack);
-        stack.push(Value::I32(d.literal.push(Literal::f64_unsuffixed(f))));
+        let f = popf64(interp);
+        interp.push(Value::I32(d.literal.push(Literal::f64_unsuffixed(f))));
         None
     })
 }
 
 // args: [Int(F64)]
 // result: [Int(I32)]
-pub fn literal_f64_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_f64_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let f = popf64(stack);
-        stack.push(Value::I32(d.literal.push(Literal::f64_suffixed(f))));
+        let f = popf64(interp);
+        interp.push(Value::I32(d.literal.push(Literal::f64_suffixed(f))));
         None
     })
 }
 
 // args: [Int(F32)]
 // result: [Int(I32)]
-pub fn literal_f32_unsuffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_f32_unsuffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let f = popf(stack);
-        stack.push(Value::I32(d.literal.push(Literal::f32_unsuffixed(f))));
+        let f = popf(interp);
+        interp.push(Value::I32(d.literal.push(Literal::f32_unsuffixed(f))));
         None
     })
 }
 
 // args: [Int(F32)]
 // result: [Int(I32)]
-pub fn literal_f32_suffixed(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_f32_suffixed(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let f = popf(stack);
-        stack.push(Value::I32(d.literal.push(Literal::f32_suffixed(f))));
+        let f = popf(interp);
+        interp.push(Value::I32(d.literal.push(Literal::f32_suffixed(f))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_string(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_string(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let string = &d.string[pop(stack)];
-        stack.push(Value::I32(d.literal.push(Literal::string(string))));
+        let string = &d.string[pop(interp)];
+        interp.push(Value::I32(d.literal.push(Literal::string(string))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_character(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_character(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let ch = char::from_u32(pop(stack)).unwrap();
-        stack.push(Value::I32(d.literal.push(Literal::character(ch))));
+        let ch = char::from_u32(pop(interp)).unwrap();
+        interp.push(Value::I32(d.literal.push(Literal::character(ch))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_byte_string(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_byte_string(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let bytes = &d.bytes[pop(stack)];
-        stack.push(Value::I32(d.literal.push(Literal::byte_string(bytes))));
+        let bytes = &d.bytes[pop(interp)];
+        interp.push(Value::I32(d.literal.push(Literal::byte_string(bytes))));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_span(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_span(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let literal = &d.literal[pop(stack)];
-        stack.push(Value::I32(d.span.push(literal.span())));
+        let literal = &d.literal[pop(interp)];
+        interp.push(Value::I32(d.span.push(literal.span())));
         None
     })
 }
 
 // args: [Int(I32), Int(I32)]
 // result: []
-pub fn literal_set_span(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_set_span(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let span = d.span[pop(stack)];
-        let literal = &mut d.literal[pop(stack)];
+        let span = d.span[pop(interp)];
+        let literal = &mut d.literal[pop(interp)];
         literal.set_span(span);
         None
     })
@@ -804,191 +804,191 @@ pub fn literal_set_span(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_stream_clone(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_clone(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let clone = d.tokenstream[pop(stack)].clone();
-        stack.push(Value::I32(d.tokenstream.push(clone)));
+        let clone = d.tokenstream[pop(interp)].clone();
+        interp.push(Value::I32(d.tokenstream.push(clone)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn group_clone(stack: &mut Vec<Value>) -> Option<String> {
+pub fn group_clone(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let clone = d.group[pop(stack)].clone();
-        stack.push(Value::I32(d.group.push(clone)));
+        let clone = d.group[pop(interp)].clone();
+        interp.push(Value::I32(d.group.push(clone)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn ident_clone(stack: &mut Vec<Value>) -> Option<String> {
+pub fn ident_clone(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let clone = d.ident[pop(stack)].clone();
-        stack.push(Value::I32(d.ident.push(clone)));
+        let clone = d.ident[pop(interp)].clone();
+        interp.push(Value::I32(d.ident.push(clone)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn punct_clone(stack: &mut Vec<Value>) -> Option<String> {
+pub fn punct_clone(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let clone = d.punct[pop(stack)].clone();
-        stack.push(Value::I32(d.punct.push(clone)));
+        let clone = d.punct[pop(interp)].clone();
+        interp.push(Value::I32(d.punct.push(clone)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_clone(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_clone(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let clone = d.literal[pop(stack)].clone();
-        stack.push(Value::I32(d.literal.push(clone)));
+        let clone = d.literal[pop(interp)].clone();
+        interp.push(Value::I32(d.literal.push(clone)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_stream_iter_clone(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_iter_clone(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let clone = d.intoiter[pop(stack)].clone();
-        stack.push(Value::I32(d.intoiter.push(clone)));
+        let clone = d.intoiter[pop(interp)].clone();
+        interp.push(Value::I32(d.intoiter.push(clone)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_stream_to_string(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_to_string(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let string = d.tokenstream[pop(stack)].to_string();
-        stack.push(Value::I32(d.string.push(string)));
+        let string = d.tokenstream[pop(interp)].to_string();
+        interp.push(Value::I32(d.string.push(string)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn group_to_string(stack: &mut Vec<Value>) -> Option<String> {
+pub fn group_to_string(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let string = d.group[pop(stack)].to_string();
-        stack.push(Value::I32(d.string.push(string)));
+        let string = d.group[pop(interp)].to_string();
+        interp.push(Value::I32(d.string.push(string)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn ident_to_string(stack: &mut Vec<Value>) -> Option<String> {
+pub fn ident_to_string(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let string = d.ident[pop(stack)].to_string();
-        stack.push(Value::I32(d.string.push(string)));
+        let string = d.ident[pop(interp)].to_string();
+        interp.push(Value::I32(d.string.push(string)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn punct_to_string(stack: &mut Vec<Value>) -> Option<String> {
+pub fn punct_to_string(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let string = d.punct[pop(stack)].to_string();
-        stack.push(Value::I32(d.string.push(string)));
+        let string = d.punct[pop(interp)].to_string();
+        interp.push(Value::I32(d.string.push(string)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_to_string(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_to_string(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let string = d.literal[pop(stack)].to_string();
-        stack.push(Value::I32(d.string.push(string)));
+        let string = d.literal[pop(interp)].to_string();
+        interp.push(Value::I32(d.string.push(string)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn token_stream_debug(stack: &mut Vec<Value>) -> Option<String> {
+pub fn token_stream_debug(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let debug = format!("{:?}", d.tokenstream[pop(stack)]);
-        stack.push(Value::I32(d.string.push(debug)));
+        let debug = format!("{:?}", d.tokenstream[pop(interp)]);
+        interp.push(Value::I32(d.string.push(debug)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn group_debug(stack: &mut Vec<Value>) -> Option<String> {
+pub fn group_debug(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let debug = format!("{:?}", d.group[pop(stack)]);
-        stack.push(Value::I32(d.string.push(debug)));
+        let debug = format!("{:?}", d.group[pop(interp)]);
+        interp.push(Value::I32(d.string.push(debug)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn ident_debug(stack: &mut Vec<Value>) -> Option<String> {
+pub fn ident_debug(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let debug = format!("{:?}", d.ident[pop(stack)]);
-        stack.push(Value::I32(d.string.push(debug)));
+        let debug = format!("{:?}", d.ident[pop(interp)]);
+        interp.push(Value::I32(d.string.push(debug)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn punct_debug(stack: &mut Vec<Value>) -> Option<String> {
+pub fn punct_debug(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let debug = format!("{:?}", d.punct[pop(stack)]);
-        stack.push(Value::I32(d.string.push(debug)));
+        let debug = format!("{:?}", d.punct[pop(interp)]);
+        interp.push(Value::I32(d.string.push(debug)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_debug(stack: &mut Vec<Value>) -> Option<String> {
+pub fn literal_debug(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let debug = format!("{:?}", d.literal[pop(stack)]);
-        stack.push(Value::I32(d.string.push(debug)));
+        let debug = format!("{:?}", d.literal[pop(interp)]);
+        interp.push(Value::I32(d.string.push(debug)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn span_debug(stack: &mut Vec<Value>) -> Option<String> {
+pub fn span_debug(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let debug = format!("{:?}", d.span[pop(stack)]);
-        stack.push(Value::I32(d.string.push(debug)));
+        let debug = format!("{:?}", d.span[pop(interp)]);
+        interp.push(Value::I32(d.string.push(debug)));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn watt_string_with_capacity(stack: &mut Vec<Value>) -> Option<String> {
+pub fn watt_string_with_capacity(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let cap = pop(stack) as usize;
+        let cap = pop(interp) as usize;
         let string = d.string.push(String::with_capacity(cap));
-        stack.push(Value::I32(string));
+        interp.push(Value::I32(string));
         None
     })
 }
 
 // args: [Int(I32), Int(I32)]
 // result: []
-pub fn watt_string_push_char(stack: &mut Vec<Value>) -> Option<String> {
+pub fn watt_string_push_char(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let ch = pop(stack);
-        let string = &mut d.string[pop(stack)];
+        let ch = pop(interp);
+        let string = &mut d.string[pop(interp)];
         string.push(char::from_u32(ch).unwrap());
         None
     })
@@ -996,43 +996,43 @@ pub fn watt_string_push_char(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn watt_string_len(stack: &mut Vec<Value>) -> Option<String> {
+pub fn watt_string_len(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let string = &d.string[pop(stack)];
-        stack.push(Value::I32(string.len() as u32));
+        let string = &d.string[pop(interp)];
+        interp.push(Value::I32(string.len() as u32));
         None
     })
 }
 
 // args: [Int(I32), Int(I32)]
 // result: [Int(I32)]
-pub fn watt_string_char_at(stack: &mut Vec<Value>) -> Option<String> {
+pub fn watt_string_char_at(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let pos = pop(stack) as usize;
-        let string = &d.string[pop(stack)];
+        let pos = pop(interp) as usize;
+        let string = &d.string[pop(interp)];
         let ch = string[pos..].chars().next().unwrap() as u32;
-        stack.push(Value::I32(ch));
+        interp.push(Value::I32(ch));
         None
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn watt_bytes_with_capacity(stack: &mut Vec<Value>) -> Option<String> {
+pub fn watt_bytes_with_capacity(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let cap = pop(stack) as usize;
+        let cap = pop(interp) as usize;
         let string = d.bytes.push(Vec::with_capacity(cap));
-        stack.push(Value::I32(string));
+        interp.push(Value::I32(string));
         None
     })
 }
 
 // args: [Int(I32), Int(I32)]
 // result: []
-pub fn watt_bytes_push(stack: &mut Vec<Value>) -> Option<String> {
+pub fn watt_bytes_push(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let b = pop(stack) as u8;
-        let bytes = &mut d.bytes[pop(stack)];
+        let b = pop(interp) as u8;
+        let bytes = &mut d.bytes[pop(interp)];
         bytes.push(b);
         None
     })
@@ -1040,34 +1040,34 @@ pub fn watt_bytes_push(stack: &mut Vec<Value>) -> Option<String> {
 
 // args: [Int(I32)]
 // result: []
-pub fn watt_print_panic(stack: &mut Vec<Value>) -> Option<String> {
-    Data::with(|d| panic!("{}", d.string[pop(stack)]))
+pub fn watt_print_panic(interp: &mut Interpreter) -> Option<String> {
+    Data::with(|d| panic!("{}", d.string[pop(interp)]))
 }
 
-fn pop(stack: &mut Vec<Value>) -> u32 {
-    match stack.pop() {
+fn pop(interp: &mut Interpreter) -> u32 {
+    match interp.pop() {
         Some(Value::I32(int)) => int,
-        _ => unreachable!("unexpected Value type on stack"),
+        _ => unreachable!("unexpected Value type on interp"),
     }
 }
 
-fn pop64(stack: &mut Vec<Value>) -> u64 {
-    match stack.pop() {
+fn pop64(interp: &mut Interpreter) -> u64 {
+    match interp.pop() {
         Some(Value::I64(int)) => int,
-        _ => unreachable!("unexpected Value type on stack"),
+        _ => unreachable!("unexpected Value type on interp"),
     }
 }
 
-fn popf(stack: &mut Vec<Value>) -> f32 {
-    match stack.pop() {
+fn popf(interp: &mut Interpreter) -> f32 {
+    match interp.pop() {
         Some(Value::F32(float)) => float,
-        _ => unreachable!("unexpected Value type on stack"),
+        _ => unreachable!("unexpected Value type on interp"),
     }
 }
 
-fn popf64(stack: &mut Vec<Value>) -> f64 {
-    match stack.pop() {
+fn popf64(interp: &mut Interpreter) -> f64 {
+    match interp.pop() {
         Some(Value::F64(float)) => float,
-        _ => unreachable!("unexpected Value type on stack"),
+        _ => unreachable!("unexpected Value type on interp"),
     }
 }

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -972,24 +972,15 @@ pub fn span_debug(interp: &mut Interpreter) -> Option<String> {
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn watt_string_with_capacity(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let cap = pop(interp) as usize;
-        let string = d.string.push(String::with_capacity(cap));
-        interp.push(Value::I32(string));
-        None
-    })
-}
-
 // args: [Int(I32), Int(I32)]
-// result: []
-pub fn watt_string_push_char(interp: &mut Interpreter) -> Option<String> {
+// result: [Int(I32)]
+pub fn watt_string_new(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let ch = pop(interp);
-        let string = &mut d.string[pop(interp)];
-        string.push(char::from_u32(ch).unwrap());
+        let len = pop(interp) as usize;
+        let ptr = pop(interp) as usize;
+        let bytes = interp.get_memory_mut()[ptr..ptr + len].to_owned();
+        let string = String::from_utf8(bytes).expect("non-utf8");
+        interp.push(Value::I32(d.string.push(string)));
         None
     })
 }
@@ -1005,35 +996,24 @@ pub fn watt_string_len(interp: &mut Interpreter) -> Option<String> {
 }
 
 // args: [Int(I32), Int(I32)]
-// result: [Int(I32)]
-pub fn watt_string_char_at(interp: &mut Interpreter) -> Option<String> {
+// result: []
+pub fn watt_string_read(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let pos = pop(interp) as usize;
+        let ptr = pop(interp) as usize;
         let string = &d.string[pop(interp)];
-        let ch = string[pos..].chars().next().unwrap() as u32;
-        interp.push(Value::I32(ch));
-        None
-    })
-}
-
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn watt_bytes_with_capacity(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let cap = pop(interp) as usize;
-        let string = d.bytes.push(Vec::with_capacity(cap));
-        interp.push(Value::I32(string));
+        interp.get_memory_mut()[ptr..ptr + string.len()].copy_from_slice(string.as_bytes());
         None
     })
 }
 
 // args: [Int(I32), Int(I32)]
-// result: []
-pub fn watt_bytes_push(interp: &mut Interpreter) -> Option<String> {
+// result: [Int(I32)]
+pub fn watt_bytes_new(interp: &mut Interpreter) -> Option<String> {
     Data::with(|d| {
-        let b = pop(interp) as u8;
-        let bytes = &mut d.bytes[pop(interp)];
-        bytes.push(b);
+        let len = pop(interp) as usize;
+        let ptr = pop(interp) as usize;
+        let bytes = interp.get_memory_mut()[ptr..ptr + len].to_owned();
+        interp.push(Value::I32(d.bytes.push(bytes)));
         None
     })
 }


### PR DESCRIPTION
This is a patch stack to refactor the way strings are copied into and out-of WASM memory. The first few parts move important interpreter state out of argument lists and store it within the `Interpreter` struct itself. This simplifies call-sites within `interpreter.rs`, by reducing the number of arguments which need to be passed, and ensures that all relevant execution state is passed as a unit. The `HostFunc` interface is then changed to take a `&mut Interpreter` instead of a `&mut Vec<Value>`.

This change allows for host functions to interact with the underlying WASM state, e.g. by calling methods or accessing memory.

In this stack, the only added functionality used is memory access. The string methods are refactored to perform bulk memory copies into and out of wasm memory, substantially improving performance when working with very large strings.

In the future, more interesting changes could be done, such as allocating and initializing values to return from the host with an exported `wasm_alloc` method.