### PR TITLE
Add initial support for running via an on-system JIT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ script:
   - cargo build --manifest-path demo/impl/Cargo.toml --release --target wasm32-unknown-unknown
   - cargo run --manifest-path demo/caller/Cargo.toml
   - cargo test --manifest-path runtime/tests/Cargo.toml
+  - WATT_JIT=1 cargo check

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=WATT_JIT");
+
+    if std::env::var("WATT_JIT").is_ok() {
+        println!("cargo:rustc-link-search=native=/home/alex/code/wasmtime/target/release");
+        println!("cargo:rustc-link-lib=static=wasmtime_api");
+        println!("cargo:rustc-cfg=jit");
+    }
+}

--- a/jit/src/engine.rs
+++ b/jit/src/engine.rs
@@ -1,0 +1,24 @@
+use super::ffi;
+
+#[repr(transparent)]
+pub struct Engine {
+    pub(crate) raw: *mut ffi::wasm_engine_t,
+}
+
+impl Engine {
+    pub fn new() -> Engine {
+        unsafe {
+            let raw = ffi::wasm_engine_new();
+            assert!(!raw.is_null());
+            Engine { raw }
+        }
+    }
+}
+
+impl Drop for Engine {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::wasm_engine_delete(self.raw);
+        }
+    }
+}

--- a/jit/src/ffi.rs
+++ b/jit/src/ffi.rs
@@ -1,0 +1,662 @@
+#![allow(bad_style)]
+#![allow(dead_code)]
+
+use std::ffi::c_void;
+
+pub type wasm_name_t = wasm_byte_vec_t;
+pub type wasm_valkind_t = u8;
+pub type wasm_externkind_t = u8;
+pub type wasm_message_t = wasm_name_t;
+pub type wasm_func_callback_t = Option<
+    unsafe extern "C" fn(args: *const wasm_val_t, results: *mut wasm_val_t) -> *mut wasm_trap_t,
+>;
+pub type wasm_func_callback_with_env_t = Option<
+    unsafe extern "C" fn(
+        env: *mut c_void,
+        args: *const wasm_val_t,
+        results: *mut wasm_val_t,
+    ) -> *mut wasm_trap_t,
+>;
+pub type wasm_table_size_t = u32;
+pub type wasm_memory_pages_t = u32;
+pub type wasm_mutability_t = u8;
+pub const WASM_I32: wasm_valkind_t = 0;
+pub const WASM_I64: wasm_valkind_t = 1;
+pub const WASM_F32: wasm_valkind_t = 2;
+pub const WASM_F64: wasm_valkind_t = 3;
+
+pub const WASM_EXTERN_FUNC: wasm_externkind_t = 0;
+pub const WASM_EXTERN_GLOBAL: wasm_externkind_t = 1;
+pub const WASM_EXTERN_TABLE: wasm_externkind_t = 2;
+pub const WASM_EXTERN_MEMORY: wasm_externkind_t = 3;
+
+#[repr(C)]
+pub struct wasm_byte_vec_t {
+    pub size: usize,
+    pub data: *mut u8,
+}
+#[repr(C)]
+pub struct wasm_extern_vec_t {
+    pub size: usize,
+    pub data: *mut *mut wasm_extern_t,
+}
+#[repr(C)]
+pub struct wasm_extern_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_memory_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_table_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_global_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_func_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_shared_module_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_module_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_foreign_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_trap_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_instance_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_frame_vec_t {
+    pub size: usize,
+    pub data: *mut *mut wasm_frame_t,
+}
+#[repr(C)]
+pub struct wasm_frame_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_val_vec_t {
+    pub size: usize,
+    pub data: *mut wasm_val_t,
+}
+#[repr(C)]
+pub struct wasm_val_t {
+    pub kind: wasm_valkind_t,
+    pub of: wasm_val_t_union,
+}
+#[repr(C)]
+pub union wasm_val_t_union {
+    pub i32: i32,
+    pub i64: i64,
+    pub f32: f32,
+    pub f64: f64,
+    pub ref_: *mut wasm_ref_t,
+}
+#[repr(C)]
+pub struct wasm_ref_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_exporttype_vec_t {
+    pub size: usize,
+    pub data: *mut *mut wasm_exporttype_t,
+}
+#[repr(C)]
+pub struct wasm_exporttype_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_importtype_vec_t {
+    pub size: usize,
+    pub data: *mut *mut wasm_importtype_t,
+}
+#[repr(C)]
+pub struct wasm_importtype_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_externtype_vec_t {
+    pub size: usize,
+    pub data: *mut *mut wasm_externtype_t,
+}
+#[repr(C)]
+pub struct wasm_externtype_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_memorytype_vec_t {
+    pub size: usize,
+    pub data: *mut *mut wasm_memorytype_t,
+}
+#[repr(C)]
+pub struct wasm_memorytype_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_tabletype_vec_t {
+    pub size: usize,
+    pub data: *mut *mut wasm_tabletype_t,
+}
+#[repr(C)]
+pub struct wasm_tabletype_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_globaltype_vec_t {
+    pub size: usize,
+    pub data: *mut *mut wasm_globaltype_t,
+}
+#[repr(C)]
+pub struct wasm_globaltype_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_functype_vec_t {
+    pub size: usize,
+    pub data: *mut *mut wasm_functype_t,
+}
+#[repr(C)]
+pub struct wasm_functype_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_valtype_vec_t {
+    pub size: usize,
+    pub data: *mut *mut wasm_valtype_t,
+}
+#[repr(C)]
+pub struct wasm_limits_t {
+    pub min: u32,
+    pub max: u32,
+}
+
+#[repr(C)]
+pub struct wasm_valtype_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_store_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_engine_t {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+pub struct wasm_config_t {
+    _unused: [u8; 0],
+}
+
+#[link(name = "wasmtime_api")]
+extern "C" {
+    pub fn wasm_byte_vec_new_empty(out: *mut wasm_byte_vec_t);
+    pub fn wasm_byte_vec_new_uninitialized(out: *mut wasm_byte_vec_t, arg1: usize);
+    pub fn wasm_byte_vec_new(out: *mut wasm_byte_vec_t, arg1: usize, arg2: *const u8);
+    pub fn wasm_byte_vec_copy(out: *mut wasm_byte_vec_t, arg1: *mut wasm_byte_vec_t);
+    pub fn wasm_byte_vec_delete(arg1: *mut wasm_byte_vec_t);
+    pub fn wasm_config_delete(arg1: *mut wasm_config_t);
+    pub fn wasm_config_new() -> *mut wasm_config_t;
+    pub fn wasm_engine_delete(arg1: *mut wasm_engine_t);
+    pub fn wasm_engine_new() -> *mut wasm_engine_t;
+    pub fn wasm_engine_new_with_config(arg1: *mut wasm_config_t) -> *mut wasm_engine_t;
+    pub fn wasm_store_delete(arg1: *mut wasm_store_t);
+    pub fn wasm_store_new(arg1: *mut wasm_engine_t) -> *mut wasm_store_t;
+    pub fn wasm_valtype_delete(arg1: *mut wasm_valtype_t);
+    pub fn wasm_valtype_vec_new_empty(out: *mut wasm_valtype_vec_t);
+    pub fn wasm_valtype_vec_new_uninitialized(out: *mut wasm_valtype_vec_t, arg1: usize);
+    pub fn wasm_valtype_vec_new(
+        out: *mut wasm_valtype_vec_t,
+        arg1: usize,
+        arg2: *const *mut wasm_valtype_t,
+    );
+    pub fn wasm_valtype_vec_copy(out: *mut wasm_valtype_vec_t, arg1: *mut wasm_valtype_vec_t);
+    pub fn wasm_valtype_vec_delete(arg1: *mut wasm_valtype_vec_t);
+    pub fn wasm_valtype_copy(arg1: *mut wasm_valtype_t) -> *mut wasm_valtype_t;
+    pub fn wasm_valtype_new(arg1: wasm_valkind_t) -> *mut wasm_valtype_t;
+    pub fn wasm_valtype_kind(arg1: *const wasm_valtype_t) -> wasm_valkind_t;
+    pub fn wasm_functype_delete(arg1: *mut wasm_functype_t);
+    pub fn wasm_functype_vec_new_empty(out: *mut wasm_functype_vec_t);
+    pub fn wasm_functype_vec_new_uninitialized(out: *mut wasm_functype_vec_t, arg1: usize);
+    pub fn wasm_functype_vec_new(
+        out: *mut wasm_functype_vec_t,
+        arg1: usize,
+        arg2: *const *mut wasm_functype_t,
+    );
+    pub fn wasm_functype_vec_copy(out: *mut wasm_functype_vec_t, arg1: *mut wasm_functype_vec_t);
+    pub fn wasm_functype_vec_delete(arg1: *mut wasm_functype_vec_t);
+    pub fn wasm_functype_copy(arg1: *mut wasm_functype_t) -> *mut wasm_functype_t;
+    pub fn wasm_functype_new(
+        params: *mut wasm_valtype_vec_t,
+        results: *mut wasm_valtype_vec_t,
+    ) -> *mut wasm_functype_t;
+    pub fn wasm_functype_params(arg1: *const wasm_functype_t) -> *const wasm_valtype_vec_t;
+    pub fn wasm_functype_results(arg1: *const wasm_functype_t) -> *const wasm_valtype_vec_t;
+    pub fn wasm_globaltype_delete(arg1: *mut wasm_globaltype_t);
+    pub fn wasm_globaltype_vec_new_empty(out: *mut wasm_globaltype_vec_t);
+    pub fn wasm_globaltype_vec_new_uninitialized(out: *mut wasm_globaltype_vec_t, arg1: usize);
+    pub fn wasm_globaltype_vec_new(
+        out: *mut wasm_globaltype_vec_t,
+        arg1: usize,
+        arg2: *const *mut wasm_globaltype_t,
+    );
+    pub fn wasm_globaltype_vec_copy(
+        out: *mut wasm_globaltype_vec_t,
+        arg1: *mut wasm_globaltype_vec_t,
+    );
+    pub fn wasm_globaltype_vec_delete(arg1: *mut wasm_globaltype_vec_t);
+    pub fn wasm_globaltype_copy(arg1: *mut wasm_globaltype_t) -> *mut wasm_globaltype_t;
+    pub fn wasm_globaltype_new(
+        arg1: *mut wasm_valtype_t,
+        arg2: wasm_mutability_t,
+    ) -> *mut wasm_globaltype_t;
+    pub fn wasm_globaltype_content(arg1: *const wasm_globaltype_t) -> *const wasm_valtype_t;
+    pub fn wasm_globaltype_mutability(arg1: *const wasm_globaltype_t) -> wasm_mutability_t;
+    pub fn wasm_tabletype_delete(arg1: *mut wasm_tabletype_t);
+    pub fn wasm_tabletype_vec_new_empty(out: *mut wasm_tabletype_vec_t);
+    pub fn wasm_tabletype_vec_new_uninitialized(out: *mut wasm_tabletype_vec_t, arg1: usize);
+    pub fn wasm_tabletype_vec_new(
+        out: *mut wasm_tabletype_vec_t,
+        arg1: usize,
+        arg2: *const *mut wasm_tabletype_t,
+    );
+    pub fn wasm_tabletype_vec_copy(out: *mut wasm_tabletype_vec_t, arg1: *mut wasm_tabletype_vec_t);
+    pub fn wasm_tabletype_vec_delete(arg1: *mut wasm_tabletype_vec_t);
+    pub fn wasm_tabletype_copy(arg1: *mut wasm_tabletype_t) -> *mut wasm_tabletype_t;
+    pub fn wasm_tabletype_new(
+        arg1: *mut wasm_valtype_t,
+        arg2: *const wasm_limits_t,
+    ) -> *mut wasm_tabletype_t;
+    pub fn wasm_tabletype_element(arg1: *const wasm_tabletype_t) -> *const wasm_valtype_t;
+    pub fn wasm_tabletype_limits(arg1: *const wasm_tabletype_t) -> *const wasm_limits_t;
+    pub fn wasm_memorytype_delete(arg1: *mut wasm_memorytype_t);
+    pub fn wasm_memorytype_vec_new_empty(out: *mut wasm_memorytype_vec_t);
+    pub fn wasm_memorytype_vec_new_uninitialized(out: *mut wasm_memorytype_vec_t, arg1: usize);
+    pub fn wasm_memorytype_vec_new(
+        out: *mut wasm_memorytype_vec_t,
+        arg1: usize,
+        arg2: *const *mut wasm_memorytype_t,
+    );
+    pub fn wasm_memorytype_vec_copy(
+        out: *mut wasm_memorytype_vec_t,
+        arg1: *mut wasm_memorytype_vec_t,
+    );
+    pub fn wasm_memorytype_vec_delete(arg1: *mut wasm_memorytype_vec_t);
+    pub fn wasm_memorytype_copy(arg1: *mut wasm_memorytype_t) -> *mut wasm_memorytype_t;
+    pub fn wasm_memorytype_new(arg1: *const wasm_limits_t) -> *mut wasm_memorytype_t;
+    pub fn wasm_memorytype_limits(arg1: *const wasm_memorytype_t) -> *const wasm_limits_t;
+    pub fn wasm_externtype_delete(arg1: *mut wasm_externtype_t);
+    pub fn wasm_externtype_vec_new_empty(out: *mut wasm_externtype_vec_t);
+    pub fn wasm_externtype_vec_new_uninitialized(out: *mut wasm_externtype_vec_t, arg1: usize);
+    pub fn wasm_externtype_vec_new(
+        out: *mut wasm_externtype_vec_t,
+        arg1: usize,
+        arg2: *const *mut wasm_externtype_t,
+    );
+    pub fn wasm_externtype_vec_copy(
+        out: *mut wasm_externtype_vec_t,
+        arg1: *mut wasm_externtype_vec_t,
+    );
+    pub fn wasm_externtype_vec_delete(arg1: *mut wasm_externtype_vec_t);
+    pub fn wasm_externtype_copy(arg1: *mut wasm_externtype_t) -> *mut wasm_externtype_t;
+    pub fn wasm_externtype_kind(arg1: *const wasm_externtype_t) -> wasm_externkind_t;
+    pub fn wasm_functype_as_externtype(arg1: *mut wasm_functype_t) -> *mut wasm_externtype_t;
+    pub fn wasm_globaltype_as_externtype(arg1: *mut wasm_globaltype_t) -> *mut wasm_externtype_t;
+    pub fn wasm_tabletype_as_externtype(arg1: *mut wasm_tabletype_t) -> *mut wasm_externtype_t;
+    pub fn wasm_memorytype_as_externtype(arg1: *mut wasm_memorytype_t) -> *mut wasm_externtype_t;
+    pub fn wasm_externtype_as_functype(arg1: *mut wasm_externtype_t) -> *mut wasm_functype_t;
+    pub fn wasm_externtype_as_globaltype(arg1: *mut wasm_externtype_t) -> *mut wasm_globaltype_t;
+    pub fn wasm_externtype_as_tabletype(arg1: *mut wasm_externtype_t) -> *mut wasm_tabletype_t;
+    pub fn wasm_externtype_as_memorytype(arg1: *mut wasm_externtype_t) -> *mut wasm_memorytype_t;
+    pub fn wasm_functype_as_externtype_const(
+        arg1: *const wasm_functype_t,
+    ) -> *const wasm_externtype_t;
+    pub fn wasm_globaltype_as_externtype_const(
+        arg1: *const wasm_globaltype_t,
+    ) -> *const wasm_externtype_t;
+    pub fn wasm_tabletype_as_externtype_const(
+        arg1: *const wasm_tabletype_t,
+    ) -> *const wasm_externtype_t;
+    pub fn wasm_memorytype_as_externtype_const(
+        arg1: *const wasm_memorytype_t,
+    ) -> *const wasm_externtype_t;
+    pub fn wasm_externtype_as_functype_const(
+        arg1: *const wasm_externtype_t,
+    ) -> *const wasm_functype_t;
+    pub fn wasm_externtype_as_globaltype_const(
+        arg1: *const wasm_externtype_t,
+    ) -> *const wasm_globaltype_t;
+    pub fn wasm_externtype_as_tabletype_const(
+        arg1: *const wasm_externtype_t,
+    ) -> *const wasm_tabletype_t;
+    pub fn wasm_externtype_as_memorytype_const(
+        arg1: *const wasm_externtype_t,
+    ) -> *const wasm_memorytype_t;
+    pub fn wasm_importtype_delete(arg1: *mut wasm_importtype_t);
+    pub fn wasm_importtype_vec_new_empty(out: *mut wasm_importtype_vec_t);
+    pub fn wasm_importtype_vec_new_uninitialized(out: *mut wasm_importtype_vec_t, arg1: usize);
+    pub fn wasm_importtype_vec_new(
+        out: *mut wasm_importtype_vec_t,
+        arg1: usize,
+        arg2: *const *mut wasm_importtype_t,
+    );
+    pub fn wasm_importtype_vec_copy(
+        out: *mut wasm_importtype_vec_t,
+        arg1: *mut wasm_importtype_vec_t,
+    );
+    pub fn wasm_importtype_vec_delete(arg1: *mut wasm_importtype_vec_t);
+    pub fn wasm_importtype_copy(arg1: *mut wasm_importtype_t) -> *mut wasm_importtype_t;
+    pub fn wasm_importtype_new(
+        module: *mut wasm_name_t,
+        name: *mut wasm_name_t,
+        arg1: *mut wasm_externtype_t,
+    ) -> *mut wasm_importtype_t;
+    pub fn wasm_importtype_module(arg1: *const wasm_importtype_t) -> *const wasm_name_t;
+    pub fn wasm_importtype_name(arg1: *const wasm_importtype_t) -> *const wasm_name_t;
+    pub fn wasm_importtype_type(arg1: *const wasm_importtype_t) -> *const wasm_externtype_t;
+    pub fn wasm_exporttype_delete(arg1: *mut wasm_exporttype_t);
+    pub fn wasm_exporttype_vec_new_empty(out: *mut wasm_exporttype_vec_t);
+    pub fn wasm_exporttype_vec_new_uninitialized(out: *mut wasm_exporttype_vec_t, arg1: usize);
+    pub fn wasm_exporttype_vec_new(
+        out: *mut wasm_exporttype_vec_t,
+        arg1: usize,
+        arg2: *const *mut wasm_exporttype_t,
+    );
+    pub fn wasm_exporttype_vec_copy(
+        out: *mut wasm_exporttype_vec_t,
+        arg1: *mut wasm_exporttype_vec_t,
+    );
+    pub fn wasm_exporttype_vec_delete(arg1: *mut wasm_exporttype_vec_t);
+    pub fn wasm_exporttype_copy(arg1: *mut wasm_exporttype_t) -> *mut wasm_exporttype_t;
+    pub fn wasm_exporttype_new(
+        arg1: *mut wasm_name_t,
+        arg2: *mut wasm_externtype_t,
+    ) -> *mut wasm_exporttype_t;
+    pub fn wasm_exporttype_name(arg1: *const wasm_exporttype_t) -> *const wasm_name_t;
+    pub fn wasm_exporttype_type(arg1: *const wasm_exporttype_t) -> *const wasm_externtype_t;
+    pub fn wasm_val_delete(v: *mut wasm_val_t);
+    pub fn wasm_val_copy(out: *mut wasm_val_t, arg1: *const wasm_val_t);
+    pub fn wasm_val_vec_new_empty(out: *mut wasm_val_vec_t);
+    pub fn wasm_val_vec_new_uninitialized(out: *mut wasm_val_vec_t, arg1: usize);
+    pub fn wasm_val_vec_new(out: *mut wasm_val_vec_t, arg1: usize, arg2: *const wasm_val_t);
+    pub fn wasm_val_vec_copy(out: *mut wasm_val_vec_t, arg1: *mut wasm_val_vec_t);
+    pub fn wasm_val_vec_delete(arg1: *mut wasm_val_vec_t);
+    pub fn wasm_ref_delete(arg1: *mut wasm_ref_t);
+    pub fn wasm_ref_copy(arg1: *const wasm_ref_t) -> *mut wasm_ref_t;
+    pub fn wasm_ref_same(arg1: *const wasm_ref_t, arg2: *const wasm_ref_t) -> bool;
+    pub fn wasm_ref_get_host_info(arg1: *const wasm_ref_t) -> *mut c_void;
+    pub fn wasm_ref_set_host_info(arg1: *mut wasm_ref_t, arg2: *mut c_void);
+    pub fn wasm_ref_set_host_info_with_finalizer(
+        arg1: *mut wasm_ref_t,
+        arg2: *mut c_void,
+        arg3: Option<unsafe extern "C" fn(arg1: *mut c_void)>,
+    );
+    pub fn wasm_frame_delete(arg1: *mut wasm_frame_t);
+    pub fn wasm_frame_vec_new_empty(out: *mut wasm_frame_vec_t);
+    pub fn wasm_frame_vec_new_uninitialized(out: *mut wasm_frame_vec_t, arg1: usize);
+    pub fn wasm_frame_vec_new(
+        out: *mut wasm_frame_vec_t,
+        arg1: usize,
+        arg2: *const *mut wasm_frame_t,
+    );
+    pub fn wasm_frame_vec_copy(out: *mut wasm_frame_vec_t, arg1: *mut wasm_frame_vec_t);
+    pub fn wasm_frame_vec_delete(arg1: *mut wasm_frame_vec_t);
+    pub fn wasm_frame_copy(arg1: *const wasm_frame_t) -> *mut wasm_frame_t;
+    pub fn wasm_frame_instance(arg1: *const wasm_frame_t) -> *mut wasm_instance_t;
+    pub fn wasm_frame_func_index(arg1: *const wasm_frame_t) -> u32;
+    pub fn wasm_frame_func_offset(arg1: *const wasm_frame_t) -> usize;
+    pub fn wasm_frame_module_offset(arg1: *const wasm_frame_t) -> usize;
+    pub fn wasm_trap_delete(arg1: *mut wasm_trap_t);
+    pub fn wasm_trap_copy(arg1: *const wasm_trap_t) -> *mut wasm_trap_t;
+    pub fn wasm_trap_same(arg1: *const wasm_trap_t, arg2: *const wasm_trap_t) -> bool;
+    pub fn wasm_trap_get_host_info(arg1: *const wasm_trap_t) -> *mut c_void;
+    pub fn wasm_trap_set_host_info(arg1: *mut wasm_trap_t, arg2: *mut c_void);
+    pub fn wasm_trap_set_host_info_with_finalizer(
+        arg1: *mut wasm_trap_t,
+        arg2: *mut c_void,
+        arg3: Option<unsafe extern "C" fn(arg1: *mut c_void)>,
+    );
+    pub fn wasm_trap_as_ref(arg1: *mut wasm_trap_t) -> *mut wasm_ref_t;
+    pub fn wasm_ref_as_trap(arg1: *mut wasm_ref_t) -> *mut wasm_trap_t;
+    pub fn wasm_trap_as_ref_const(arg1: *const wasm_trap_t) -> *const wasm_ref_t;
+    pub fn wasm_ref_as_trap_const(arg1: *const wasm_ref_t) -> *const wasm_trap_t;
+    pub fn wasm_trap_new(store: *mut wasm_store_t, arg1: *const wasm_message_t)
+        -> *mut wasm_trap_t;
+    pub fn wasm_trap_message(arg1: *const wasm_trap_t, out: *mut wasm_message_t);
+    pub fn wasm_trap_origin(arg1: *const wasm_trap_t) -> *mut wasm_frame_t;
+    pub fn wasm_trap_trace(arg1: *const wasm_trap_t, out: *mut wasm_frame_vec_t);
+    pub fn wasm_foreign_delete(arg1: *mut wasm_foreign_t);
+    pub fn wasm_foreign_copy(arg1: *const wasm_foreign_t) -> *mut wasm_foreign_t;
+    pub fn wasm_foreign_same(arg1: *const wasm_foreign_t, arg2: *const wasm_foreign_t) -> bool;
+    pub fn wasm_foreign_get_host_info(arg1: *const wasm_foreign_t) -> *mut c_void;
+    pub fn wasm_foreign_set_host_info(arg1: *mut wasm_foreign_t, arg2: *mut c_void);
+    pub fn wasm_foreign_set_host_info_with_finalizer(
+        arg1: *mut wasm_foreign_t,
+        arg2: *mut c_void,
+        arg3: Option<unsafe extern "C" fn(arg1: *mut c_void)>,
+    );
+    pub fn wasm_foreign_as_ref(arg1: *mut wasm_foreign_t) -> *mut wasm_ref_t;
+    pub fn wasm_ref_as_foreign(arg1: *mut wasm_ref_t) -> *mut wasm_foreign_t;
+    pub fn wasm_foreign_as_ref_const(arg1: *const wasm_foreign_t) -> *const wasm_ref_t;
+    pub fn wasm_ref_as_foreign_const(arg1: *const wasm_ref_t) -> *const wasm_foreign_t;
+    pub fn wasm_foreign_new(arg1: *mut wasm_store_t) -> *mut wasm_foreign_t;
+    pub fn wasm_module_delete(arg1: *mut wasm_module_t);
+    pub fn wasm_module_copy(arg1: *const wasm_module_t) -> *mut wasm_module_t;
+    pub fn wasm_module_same(arg1: *const wasm_module_t, arg2: *const wasm_module_t) -> bool;
+    pub fn wasm_module_get_host_info(arg1: *const wasm_module_t) -> *mut c_void;
+    pub fn wasm_module_set_host_info(arg1: *mut wasm_module_t, arg2: *mut c_void);
+    pub fn wasm_module_set_host_info_with_finalizer(
+        arg1: *mut wasm_module_t,
+        arg2: *mut c_void,
+        arg3: Option<unsafe extern "C" fn(arg1: *mut c_void)>,
+    );
+    pub fn wasm_module_as_ref(arg1: *mut wasm_module_t) -> *mut wasm_ref_t;
+    pub fn wasm_ref_as_module(arg1: *mut wasm_ref_t) -> *mut wasm_module_t;
+    pub fn wasm_module_as_ref_const(arg1: *const wasm_module_t) -> *const wasm_ref_t;
+    pub fn wasm_ref_as_module_const(arg1: *const wasm_ref_t) -> *const wasm_module_t;
+    pub fn wasm_shared_module_delete(arg1: *mut wasm_shared_module_t);
+    pub fn wasm_module_share(arg1: *const wasm_module_t) -> *mut wasm_shared_module_t;
+    pub fn wasm_module_obtain(
+        arg1: *mut wasm_store_t,
+        arg2: *const wasm_shared_module_t,
+    ) -> *mut wasm_module_t;
+    pub fn wasm_module_new(
+        arg1: *mut wasm_store_t,
+        binary: *const wasm_byte_vec_t,
+    ) -> *mut wasm_module_t;
+    pub fn wasm_module_validate(arg1: *mut wasm_store_t, binary: *const wasm_byte_vec_t) -> bool;
+    pub fn wasm_module_imports(arg1: *const wasm_module_t, out: *mut wasm_importtype_vec_t);
+    pub fn wasm_module_exports(arg1: *const wasm_module_t, out: *mut wasm_exporttype_vec_t);
+    pub fn wasm_module_serialize(arg1: *const wasm_module_t, out: *mut wasm_byte_vec_t);
+    pub fn wasm_module_deserialize(
+        arg1: *mut wasm_store_t,
+        arg2: *const wasm_byte_vec_t,
+    ) -> *mut wasm_module_t;
+    pub fn wasm_func_delete(arg1: *mut wasm_func_t);
+    pub fn wasm_func_copy(arg1: *const wasm_func_t) -> *mut wasm_func_t;
+    pub fn wasm_func_same(arg1: *const wasm_func_t, arg2: *const wasm_func_t) -> bool;
+    pub fn wasm_func_get_host_info(arg1: *const wasm_func_t) -> *mut c_void;
+    pub fn wasm_func_set_host_info(arg1: *mut wasm_func_t, arg2: *mut c_void);
+    pub fn wasm_func_set_host_info_with_finalizer(
+        arg1: *mut wasm_func_t,
+        arg2: *mut c_void,
+        arg3: Option<unsafe extern "C" fn(arg1: *mut c_void)>,
+    );
+    pub fn wasm_func_as_ref(arg1: *mut wasm_func_t) -> *mut wasm_ref_t;
+    pub fn wasm_ref_as_func(arg1: *mut wasm_ref_t) -> *mut wasm_func_t;
+    pub fn wasm_func_as_ref_const(arg1: *const wasm_func_t) -> *const wasm_ref_t;
+    pub fn wasm_ref_as_func_const(arg1: *const wasm_ref_t) -> *const wasm_func_t;
+    pub fn wasm_func_new(
+        arg1: *mut wasm_store_t,
+        arg2: *const wasm_functype_t,
+        arg3: wasm_func_callback_t,
+    ) -> *mut wasm_func_t;
+    pub fn wasm_func_new_with_env(
+        arg1: *mut wasm_store_t,
+        type_: *const wasm_functype_t,
+        arg2: wasm_func_callback_with_env_t,
+        env: *mut c_void,
+        finalizer: Option<unsafe extern "C" fn(arg1: *mut c_void)>,
+    ) -> *mut wasm_func_t;
+    pub fn wasm_func_type(arg1: *const wasm_func_t) -> *mut wasm_functype_t;
+    pub fn wasm_func_param_arity(arg1: *const wasm_func_t) -> usize;
+    pub fn wasm_func_result_arity(arg1: *const wasm_func_t) -> usize;
+    pub fn wasm_func_call(
+        arg1: *const wasm_func_t,
+        args: *const wasm_val_t,
+        results: *mut wasm_val_t,
+    ) -> *mut wasm_trap_t;
+    pub fn wasm_global_delete(arg1: *mut wasm_global_t);
+    pub fn wasm_global_copy(arg1: *const wasm_global_t) -> *mut wasm_global_t;
+    pub fn wasm_global_same(arg1: *const wasm_global_t, arg2: *const wasm_global_t) -> bool;
+    pub fn wasm_global_get_host_info(arg1: *const wasm_global_t) -> *mut c_void;
+    pub fn wasm_global_set_host_info(arg1: *mut wasm_global_t, arg2: *mut c_void);
+    pub fn wasm_global_set_host_info_with_finalizer(
+        arg1: *mut wasm_global_t,
+        arg2: *mut c_void,
+        arg3: Option<unsafe extern "C" fn(arg1: *mut c_void)>,
+    );
+    pub fn wasm_global_as_ref(arg1: *mut wasm_global_t) -> *mut wasm_ref_t;
+    pub fn wasm_ref_as_global(arg1: *mut wasm_ref_t) -> *mut wasm_global_t;
+    pub fn wasm_global_as_ref_const(arg1: *const wasm_global_t) -> *const wasm_ref_t;
+    pub fn wasm_ref_as_global_const(arg1: *const wasm_ref_t) -> *const wasm_global_t;
+    pub fn wasm_global_new(
+        arg1: *mut wasm_store_t,
+        arg2: *const wasm_globaltype_t,
+        arg3: *const wasm_val_t,
+    ) -> *mut wasm_global_t;
+    pub fn wasm_global_type(arg1: *const wasm_global_t) -> *mut wasm_globaltype_t;
+    pub fn wasm_global_get(arg1: *const wasm_global_t, out: *mut wasm_val_t);
+    pub fn wasm_global_set(arg1: *mut wasm_global_t, arg2: *const wasm_val_t);
+    pub fn wasm_table_delete(arg1: *mut wasm_table_t);
+    pub fn wasm_table_copy(arg1: *const wasm_table_t) -> *mut wasm_table_t;
+    pub fn wasm_table_same(arg1: *const wasm_table_t, arg2: *const wasm_table_t) -> bool;
+    pub fn wasm_table_get_host_info(arg1: *const wasm_table_t) -> *mut c_void;
+    pub fn wasm_table_set_host_info(arg1: *mut wasm_table_t, arg2: *mut c_void);
+    pub fn wasm_table_set_host_info_with_finalizer(
+        arg1: *mut wasm_table_t,
+        arg2: *mut c_void,
+        arg3: Option<unsafe extern "C" fn(arg1: *mut c_void)>,
+    );
+    pub fn wasm_table_as_ref(arg1: *mut wasm_table_t) -> *mut wasm_ref_t;
+    pub fn wasm_ref_as_table(arg1: *mut wasm_ref_t) -> *mut wasm_table_t;
+    pub fn wasm_table_as_ref_const(arg1: *const wasm_table_t) -> *const wasm_ref_t;
+    pub fn wasm_ref_as_table_const(arg1: *const wasm_ref_t) -> *const wasm_table_t;
+    pub fn wasm_table_new(
+        arg1: *mut wasm_store_t,
+        arg2: *const wasm_tabletype_t,
+        init: *mut wasm_ref_t,
+    ) -> *mut wasm_table_t;
+    pub fn wasm_table_type(arg1: *const wasm_table_t) -> *mut wasm_tabletype_t;
+    pub fn wasm_table_get(arg1: *const wasm_table_t, index: wasm_table_size_t) -> *mut wasm_ref_t;
+    pub fn wasm_table_set(
+        arg1: *mut wasm_table_t,
+        index: wasm_table_size_t,
+        arg2: *mut wasm_ref_t,
+    ) -> bool;
+    pub fn wasm_table_size(arg1: *const wasm_table_t) -> wasm_table_size_t;
+    pub fn wasm_table_grow(
+        arg1: *mut wasm_table_t,
+        delta: wasm_table_size_t,
+        init: *mut wasm_ref_t,
+    ) -> bool;
+    pub fn wasm_memory_delete(arg1: *mut wasm_memory_t);
+    pub fn wasm_memory_copy(arg1: *const wasm_memory_t) -> *mut wasm_memory_t;
+    pub fn wasm_memory_same(arg1: *const wasm_memory_t, arg2: *const wasm_memory_t) -> bool;
+    pub fn wasm_memory_get_host_info(arg1: *const wasm_memory_t) -> *mut c_void;
+    pub fn wasm_memory_set_host_info(arg1: *mut wasm_memory_t, arg2: *mut c_void);
+    pub fn wasm_memory_set_host_info_with_finalizer(
+        arg1: *mut wasm_memory_t,
+        arg2: *mut c_void,
+        arg3: Option<unsafe extern "C" fn(arg1: *mut c_void)>,
+    );
+    pub fn wasm_memory_as_ref(arg1: *mut wasm_memory_t) -> *mut wasm_ref_t;
+    pub fn wasm_ref_as_memory(arg1: *mut wasm_ref_t) -> *mut wasm_memory_t;
+    pub fn wasm_memory_as_ref_const(arg1: *const wasm_memory_t) -> *const wasm_ref_t;
+    pub fn wasm_ref_as_memory_const(arg1: *const wasm_ref_t) -> *const wasm_memory_t;
+    pub fn wasm_memory_new(
+        arg1: *mut wasm_store_t,
+        arg2: *const wasm_memorytype_t,
+    ) -> *mut wasm_memory_t;
+    pub fn wasm_memory_type(arg1: *const wasm_memory_t) -> *mut wasm_memorytype_t;
+    pub fn wasm_memory_data(arg1: *mut wasm_memory_t) -> *mut u8;
+    pub fn wasm_memory_data_size(arg1: *const wasm_memory_t) -> usize;
+    pub fn wasm_memory_size(arg1: *const wasm_memory_t) -> wasm_memory_pages_t;
+    pub fn wasm_memory_grow(arg1: *mut wasm_memory_t, delta: wasm_memory_pages_t) -> bool;
+    pub fn wasm_extern_delete(arg1: *mut wasm_extern_t);
+    pub fn wasm_extern_copy(arg1: *const wasm_extern_t) -> *mut wasm_extern_t;
+    pub fn wasm_extern_same(arg1: *const wasm_extern_t, arg2: *const wasm_extern_t) -> bool;
+    pub fn wasm_extern_get_host_info(arg1: *const wasm_extern_t) -> *mut c_void;
+    pub fn wasm_extern_set_host_info(arg1: *mut wasm_extern_t, arg2: *mut c_void);
+    pub fn wasm_extern_set_host_info_with_finalizer(
+        arg1: *mut wasm_extern_t,
+        arg2: *mut c_void,
+        arg3: Option<unsafe extern "C" fn(arg1: *mut c_void)>,
+    );
+    pub fn wasm_extern_as_ref(arg1: *mut wasm_extern_t) -> *mut wasm_ref_t;
+    pub fn wasm_ref_as_extern(arg1: *mut wasm_ref_t) -> *mut wasm_extern_t;
+    pub fn wasm_extern_as_ref_const(arg1: *const wasm_extern_t) -> *const wasm_ref_t;
+    pub fn wasm_ref_as_extern_const(arg1: *const wasm_ref_t) -> *const wasm_extern_t;
+    pub fn wasm_extern_vec_new_empty(out: *mut wasm_extern_vec_t);
+    pub fn wasm_extern_vec_new_uninitialized(out: *mut wasm_extern_vec_t, arg1: usize);
+    pub fn wasm_extern_vec_new(
+        out: *mut wasm_extern_vec_t,
+        arg1: usize,
+        arg2: *const *mut wasm_extern_t,
+    );
+    pub fn wasm_extern_vec_copy(out: *mut wasm_extern_vec_t, arg1: *mut wasm_extern_vec_t);
+    pub fn wasm_extern_vec_delete(arg1: *mut wasm_extern_vec_t);
+    pub fn wasm_extern_kind(arg1: *const wasm_extern_t) -> wasm_externkind_t;
+    pub fn wasm_extern_type(arg1: *const wasm_extern_t) -> *mut wasm_externtype_t;
+    pub fn wasm_func_as_extern(arg1: *mut wasm_func_t) -> *mut wasm_extern_t;
+    pub fn wasm_global_as_extern(arg1: *mut wasm_global_t) -> *mut wasm_extern_t;
+    pub fn wasm_table_as_extern(arg1: *mut wasm_table_t) -> *mut wasm_extern_t;
+    pub fn wasm_memory_as_extern(arg1: *mut wasm_memory_t) -> *mut wasm_extern_t;
+    pub fn wasm_extern_as_func(arg1: *mut wasm_extern_t) -> *mut wasm_func_t;
+    pub fn wasm_extern_as_global(arg1: *mut wasm_extern_t) -> *mut wasm_global_t;
+    pub fn wasm_extern_as_table(arg1: *mut wasm_extern_t) -> *mut wasm_table_t;
+    pub fn wasm_extern_as_memory(arg1: *mut wasm_extern_t) -> *mut wasm_memory_t;
+    pub fn wasm_func_as_extern_const(arg1: *const wasm_func_t) -> *const wasm_extern_t;
+    pub fn wasm_global_as_extern_const(arg1: *const wasm_global_t) -> *const wasm_extern_t;
+    pub fn wasm_table_as_extern_const(arg1: *const wasm_table_t) -> *const wasm_extern_t;
+    pub fn wasm_memory_as_extern_const(arg1: *const wasm_memory_t) -> *const wasm_extern_t;
+    pub fn wasm_extern_as_func_const(arg1: *const wasm_extern_t) -> *const wasm_func_t;
+    pub fn wasm_extern_as_global_const(arg1: *const wasm_extern_t) -> *const wasm_global_t;
+    pub fn wasm_extern_as_table_const(arg1: *const wasm_extern_t) -> *const wasm_table_t;
+    pub fn wasm_extern_as_memory_const(arg1: *const wasm_extern_t) -> *const wasm_memory_t;
+    pub fn wasm_instance_delete(arg1: *mut wasm_instance_t);
+    pub fn wasm_instance_copy(arg1: *const wasm_instance_t) -> *mut wasm_instance_t;
+    pub fn wasm_instance_same(arg1: *const wasm_instance_t, arg2: *const wasm_instance_t) -> bool;
+    pub fn wasm_instance_get_host_info(arg1: *const wasm_instance_t) -> *mut c_void;
+    pub fn wasm_instance_set_host_info(arg1: *mut wasm_instance_t, arg2: *mut c_void);
+    pub fn wasm_instance_set_host_info_with_finalizer(
+        arg1: *mut wasm_instance_t,
+        arg2: *mut c_void,
+        arg3: Option<unsafe extern "C" fn(arg1: *mut c_void)>,
+    );
+    pub fn wasm_instance_as_ref(arg1: *mut wasm_instance_t) -> *mut wasm_ref_t;
+    pub fn wasm_ref_as_instance(arg1: *mut wasm_ref_t) -> *mut wasm_instance_t;
+    pub fn wasm_instance_as_ref_const(arg1: *const wasm_instance_t) -> *const wasm_ref_t;
+    pub fn wasm_ref_as_instance_const(arg1: *const wasm_ref_t) -> *const wasm_instance_t;
+    pub fn wasm_instance_new(
+        arg1: *mut wasm_store_t,
+        arg2: *const wasm_module_t,
+        imports: *const *const wasm_extern_t,
+        arg3: *mut *mut wasm_trap_t,
+    ) -> *mut wasm_instance_t;
+    pub fn wasm_instance_exports(arg1: *const wasm_instance_t, out: *mut wasm_extern_vec_t);
+}

--- a/jit/src/func.rs
+++ b/jit/src/func.rs
@@ -1,0 +1,189 @@
+use super::{ffi, FuncType, Store, Trap, Val, ValType, ValTypeVec};
+use std::ffi::c_void;
+use std::marker;
+use std::ptr;
+
+#[repr(transparent)]
+pub struct Func {
+    pub(crate) raw: *mut ffi::wasm_func_t,
+}
+
+impl Func {
+    unsafe fn into_host_func(
+        store: &Store,
+        ty: &FuncType,
+        callback: ffi::wasm_func_callback_with_env_t,
+        ptr: *mut c_void,
+        dtor: unsafe extern "C" fn(*mut c_void),
+    ) -> Func {
+        let raw = ffi::wasm_func_new_with_env(store.raw, ty.raw, callback, ptr, Some(dtor));
+        assert!(!raw.is_null());
+        Func { raw }
+    }
+}
+
+impl Drop for Func {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::wasm_func_delete(self.raw);
+        }
+    }
+}
+
+pub unsafe trait WasmArg: Sized {
+    fn push_valtype(list: &mut Vec<ValType>);
+    unsafe fn from(ptr: *const ffi::wasm_val_t) -> (Self, *const ffi::wasm_val_t);
+    unsafe fn into(self, ptr: *mut ffi::wasm_val_t);
+}
+
+macro_rules! wasmarg {
+    ($($a:ident)*) => ($(
+        unsafe impl WasmArg for $a {
+            fn push_valtype(list: &mut Vec<ValType>) {
+                list.push(ValType::$a());
+            }
+            unsafe fn from(ptr: *const ffi::wasm_val_t) -> ($a, *const ffi::wasm_val_t) {
+                ((*ptr).of.$a, ptr.offset(1))
+            }
+            unsafe fn into(self, ptr: *mut ffi::wasm_val_t) {
+                (*ptr).of.$a = self;
+            }
+        }
+    )*)
+}
+
+wasmarg! { i32 i64 f32 f64 }
+
+macro_rules! wasmarg_as {
+    ($($a:ident as $b:ident)*) => ($(
+        unsafe impl WasmArg for $b {
+            fn push_valtype(list: &mut Vec<ValType>) {
+                $a::push_valtype(list);
+            }
+            unsafe fn from(ptr: *const ffi::wasm_val_t) -> ($b, *const ffi::wasm_val_t) {
+                let (a, b) = <$a as WasmArg>::from(ptr);
+                (a as $b, b)
+            }
+            unsafe fn into(self, ptr: *mut ffi::wasm_val_t) {
+                <$a as WasmArg>::into(self as $a, ptr)
+            }
+        }
+    )*)
+}
+
+wasmarg_as! {
+    i32 as u32
+    i64 as u64
+}
+
+unsafe impl WasmArg for () {
+    fn push_valtype(_list: &mut Vec<ValType>) {}
+
+    unsafe fn from(ptr: *const ffi::wasm_val_t) -> ((), *const ffi::wasm_val_t) {
+        ((), ptr.offset(1))
+    }
+
+    unsafe fn into(self, _ptr: *mut ffi::wasm_val_t) {}
+}
+
+unsafe impl WasmArg for *mut [u8] {
+    fn push_valtype(_list: &mut Vec<ValType>) {}
+
+    unsafe fn from(ptr: *const ffi::wasm_val_t) -> (*mut [u8], *const ffi::wasm_val_t) {
+        (super::current_memory::with(|m| m.as_slice()), ptr)
+    }
+
+    unsafe fn into(self, _ptr: *mut ffi::wasm_val_t) {
+        unreachable!()
+    }
+}
+
+unsafe extern "C" fn dtor<T>(env: *mut c_void) {
+    drop(Box::from_raw(env as *mut T));
+}
+
+macro_rules! fnimpl {
+    ($traitname:ident $($arg:ident)*) => (
+        pub trait $traitname<$($arg),*> {
+            fn into_host_func(self, store: &Store) -> Func;
+        }
+
+        #[allow(non_snake_case)]
+        impl<F: FnMut($($arg),*) -> R, R: WasmArg, $($arg: WasmArg),*> $traitname<$($arg),*> for F {
+            fn into_host_func(self, store: &Store) -> Func {
+                let mut _params = Vec::new();
+                $($arg::push_valtype(&mut _params);)*
+                let mut results = Vec::new();
+                R::push_valtype(&mut results);
+                let ty = FuncType::new(ValTypeVec::new(&_params), ValTypeVec::new(&results));
+                let me = Box::new(self);
+                let ptr = Box::into_raw(me);
+                return unsafe {
+                    Func::into_host_func(
+                        store,
+                        &ty,
+                        Some(callback::<F, R, $($arg),*>),
+                        ptr as *mut c_void,
+                        dtor::<F>,
+                    )
+                };
+
+                unsafe extern "C" fn callback<F: FnMut($($arg),*) -> R, R: WasmArg, $($arg: WasmArg),*>(
+                    env: *mut c_void,
+                    _args: *const ffi::wasm_val_t,
+                    results: *mut ffi::wasm_val_t,
+                ) -> *mut ffi::wasm_trap_t {
+                    let env = &mut *(env as *mut F);
+                    $(
+                        let ($arg, _args) = WasmArg::from(_args);
+                    )*
+                    let ret = env($($arg),*);
+                    ret.into(results);
+                    ptr::null_mut()
+                }
+
+            }
+        }
+    );
+}
+
+fnimpl!(WasmFunc0);
+fnimpl!(WasmFunc1 A);
+fnimpl!(WasmFunc2 A B);
+fnimpl!(WasmFunc3 A B C);
+
+#[repr(transparent)]
+pub struct FuncRef<'a> {
+    pub(crate) raw: *mut ffi::wasm_func_t,
+    pub(crate) _marker: marker::PhantomData<&'a i32>,
+}
+
+impl FuncRef<'_> {
+    pub fn call(&self, args: &[Val]) -> Result<Vec<Val>, Trap> {
+        assert_eq!(args.len(), self.param_arity());
+        let mut results = Vec::new();
+        for _ in 0..self.result_arity() {
+            results.push(Val::i32(0));
+        }
+        unsafe {
+            let trap = ffi::wasm_func_call(
+                self.raw,
+                args.as_ptr() as *const ffi::wasm_val_t,
+                results.as_mut_ptr() as *mut ffi::wasm_val_t,
+            );
+            if trap.is_null() {
+                Ok(results)
+            } else {
+                Err(Trap { raw: trap })
+            }
+        }
+    }
+
+    pub fn param_arity(&self) -> usize {
+        unsafe { ffi::wasm_func_param_arity(self.raw) }
+    }
+
+    pub fn result_arity(&self) -> usize {
+        unsafe { ffi::wasm_func_result_arity(self.raw) }
+    }
+}

--- a/jit/src/functype.rs
+++ b/jit/src/functype.rs
@@ -1,0 +1,26 @@
+use super::{ffi, ValTypeVec};
+use std::mem;
+
+#[repr(transparent)]
+pub struct FuncType {
+    pub(crate) raw: *mut ffi::wasm_functype_t,
+}
+
+impl FuncType {
+    pub fn new(mut params: ValTypeVec, mut results: ValTypeVec) -> FuncType {
+        unsafe {
+            let raw = ffi::wasm_functype_new(&mut params.raw, &mut results.raw);
+            assert!(!raw.is_null());
+            mem::forget((params, results));
+            FuncType { raw }
+        }
+    }
+}
+
+impl Drop for FuncType {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::wasm_functype_delete(self.raw);
+        }
+    }
+}

--- a/jit/src/instance.rs
+++ b/jit/src/instance.rs
@@ -1,0 +1,125 @@
+use super::{ffi, Func, FuncRef, MemoryRef, Module, Store, Trap};
+use std::marker;
+use std::mem;
+use std::ops::Deref;
+use std::ptr;
+use std::slice;
+
+#[repr(transparent)]
+pub struct Instance {
+    pub(crate) raw: *mut ffi::wasm_instance_t,
+}
+
+impl Instance {
+    pub fn new(
+        store: &Store,
+        module: &Module,
+        imports: &InstanceImports,
+    ) -> Result<Instance, Trap> {
+        unsafe {
+            assert_eq!(module.imports().len(), imports.imports.len());
+            let mut trap = ptr::null_mut();
+            let raw =
+                ffi::wasm_instance_new(store.raw, module.raw, imports.imports.as_ptr(), &mut trap);
+            if raw.is_null() {
+                assert!(!trap.is_null());
+                Err(Trap { raw: trap })
+            } else {
+                Ok(Instance { raw })
+            }
+        }
+    }
+
+    pub fn exports(&self) -> ExternVec {
+        unsafe {
+            let mut raw = mem::zeroed();
+            ffi::wasm_instance_exports(self.raw, &mut raw);
+            ExternVec { raw }
+        }
+    }
+}
+
+impl Drop for Instance {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::wasm_instance_delete(self.raw);
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct InstanceImports {
+    imports: Vec<*const ffi::wasm_extern_t>,
+    funcs: Vec<Func>,
+}
+
+impl InstanceImports {
+    pub fn func(&mut self, func: Func) {
+        self.imports
+            .push(unsafe { ffi::wasm_func_as_extern(func.raw) });
+        self.funcs.push(func);
+    }
+}
+
+pub struct ExternVec {
+    raw: ffi::wasm_extern_vec_t,
+}
+
+impl Deref for ExternVec {
+    type Target = [Extern];
+
+    fn deref(&self) -> &[Extern] {
+        unsafe { slice::from_raw_parts(self.raw.data as *const Extern, self.raw.size) }
+    }
+}
+
+impl Drop for ExternVec {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::wasm_extern_vec_delete(&mut self.raw);
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct Extern {
+    raw: *mut ffi::wasm_extern_t,
+}
+
+impl Extern {
+    pub fn func(&self) -> Option<FuncRef<'_>> {
+        unsafe {
+            if ffi::wasm_extern_kind(self.raw) != ffi::WASM_EXTERN_FUNC {
+                None
+            } else {
+                Some(FuncRef {
+                    raw: ffi::wasm_extern_as_func(self.raw),
+                    _marker: marker::PhantomData,
+                })
+            }
+        }
+    }
+
+    pub fn memory(&self) -> Option<MemoryRef<'_>> {
+        unsafe {
+            if ffi::wasm_extern_kind(self.raw) != ffi::WASM_EXTERN_MEMORY {
+                None
+            } else {
+                Some(MemoryRef {
+                    raw: ffi::wasm_extern_as_memory(self.raw),
+                    _marker: marker::PhantomData,
+                })
+            }
+        }
+    }
+}
+
+impl Drop for Extern {
+    fn drop(&mut self) {
+        eprintln!("drop extern");
+        panic!()
+        // unsafe {
+        //     ffi::wasm_extern_delete(self.raw);
+        // }
+    }
+}

--- a/jit/src/lib.rs
+++ b/jit/src/lib.rs
@@ -1,0 +1,74 @@
+//! Experimental support to use a JIT to load/run wasm files
+//!
+//! This is heavily under-documented and not fully fleshed out. This is demo
+//! quality and is meant to get things up and running, this is turned off by
+//! default. Expect breakage if you use this!
+//!
+//! This currently requires a dynamic library which implements the proposed wasm
+//! C API [1] and is currently hooked up by default to `libwasmtime_api.so`.
+//!
+//! [1]: https://github.com/WebAssembly/wasm-c-api
+
+use std::slice;
+use std::str;
+
+mod engine;
+mod ffi;
+mod func;
+mod functype;
+mod instance;
+mod memory;
+mod module;
+mod store;
+mod trap;
+mod val;
+mod valtype;
+pub use self::engine::*;
+pub use self::func::*;
+pub use self::functype::*;
+pub use self::instance::*;
+pub use self::memory::*;
+pub use self::module::*;
+pub use self::store::*;
+pub use self::trap::*;
+pub use self::val::*;
+pub use self::valtype::*;
+
+unsafe fn name_to_str<'a>(name: *const ffi::wasm_name_t) -> &'a str {
+    str::from_utf8_unchecked(slice::from_raw_parts((*name).data, (*name).size))
+}
+
+pub mod current_memory {
+    use super::MemoryRef;
+    use std::cell::Cell;
+    use std::mem;
+    use std::ptr;
+
+    std::thread_local!(static CURRENT: Cell<*const MemoryRef<'static>> = Cell::new(ptr::null()));
+
+    pub fn with<R>(f: impl FnOnce(&MemoryRef<'_>) -> R) -> R {
+        CURRENT.with(|c| {
+            assert!(!c.get().is_null());
+            unsafe { f(&*c.get()) }
+        })
+    }
+
+    pub fn set<R>(mem: &MemoryRef, f: impl FnOnce() -> R) -> R {
+        struct Reset<'a, T: Copy>(T, &'a Cell<T>);
+
+        impl<T: Copy> Drop for Reset<'_, T> {
+            fn drop(&mut self) {
+                self.1.set(self.0);
+            }
+        }
+
+        CURRENT.with(|c| {
+            let prev = c.get();
+            c.set(unsafe {
+                mem::transmute::<*const MemoryRef<'_>, *const MemoryRef<'static>>(mem)
+            });
+            let _reset = Reset(prev, c);
+            f()
+        })
+    }
+}

--- a/jit/src/memory.rs
+++ b/jit/src/memory.rs
@@ -1,0 +1,19 @@
+use super::ffi;
+use std::marker;
+use std::slice;
+
+#[repr(transparent)]
+pub struct MemoryRef<'a> {
+    pub(crate) raw: *mut ffi::wasm_memory_t,
+    pub(crate) _marker: marker::PhantomData<&'a i32>,
+}
+
+impl MemoryRef<'_> {
+    pub fn as_slice(&self) -> *mut [u8] {
+        unsafe {
+            let ptr = ffi::wasm_memory_data(self.raw);
+            let len = ffi::wasm_memory_data_size(self.raw);
+            slice::from_raw_parts_mut(ptr, len)
+        }
+    }
+}

--- a/jit/src/module.rs
+++ b/jit/src/module.rs
@@ -1,0 +1,153 @@
+use super::{ffi, Store};
+use std::mem;
+use std::ops::Deref;
+use std::slice;
+use std::str;
+
+#[repr(transparent)]
+pub struct Module {
+    pub(crate) raw: *mut ffi::wasm_module_t,
+}
+
+impl Module {
+    pub fn new(store: &Store, wasm: &[u8]) -> Module {
+        unsafe {
+            let vec = ffi::wasm_byte_vec_t {
+                size: wasm.len(),
+                data: wasm.as_ptr() as *mut u8,
+            };
+            let raw = ffi::wasm_module_new(store.raw, &vec);
+            assert!(!raw.is_null());
+            Module { raw }
+        }
+    }
+
+    pub fn imports(&self) -> ImportTypeVec {
+        unsafe {
+            let mut raw = mem::zeroed();
+            ffi::wasm_module_imports(self.raw, &mut raw);
+            ImportTypeVec { raw }
+        }
+    }
+
+    pub fn exports(&self) -> ExportTypeVec {
+        unsafe {
+            let mut raw = mem::zeroed();
+            ffi::wasm_module_exports(self.raw, &mut raw);
+            ExportTypeVec { raw }
+        }
+    }
+}
+
+impl Drop for Module {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::wasm_module_delete(self.raw);
+        }
+    }
+}
+
+pub struct ImportTypeVec {
+    raw: ffi::wasm_importtype_vec_t,
+}
+
+impl Deref for ImportTypeVec {
+    type Target = [ImportType];
+
+    fn deref(&self) -> &[ImportType] {
+        unsafe { slice::from_raw_parts(self.raw.data as *const ImportType, self.raw.size) }
+    }
+}
+
+impl Drop for ImportTypeVec {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::wasm_importtype_vec_delete(&mut self.raw);
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct ImportType {
+    raw: *mut ffi::wasm_importtype_t,
+}
+
+impl ImportType {
+    pub fn module(&self) -> &str {
+        unsafe { super::name_to_str(ffi::wasm_importtype_module(self.raw)) }
+    }
+
+    pub fn name(&self) -> &str {
+        unsafe { super::name_to_str(ffi::wasm_importtype_name(self.raw)) }
+    }
+
+    // pub fn ty(&self) -> ExternType {
+    //     ExternType {
+    //         raw: unsafe { ffi::wasm_importtype_type(self.raw) },
+    //     }
+    // }
+}
+
+impl Drop for ImportType {
+    fn drop(&mut self) {
+        eprintln!("drop import type");
+        panic!()
+        // unsafe {
+        //     ffi::wasm_importtype_delete(self.raw);
+        // }
+    }
+}
+
+// #[repr(transparent)]
+// pub struct ExternType {
+//     raw: *const ffi::wasm_externtype_t,
+// }
+//
+// impl Drop for ExternType {
+//     fn drop(&mut self) {
+//         unsafe {
+//             ffi::wasm_externtype_delete(self.raw as *mut ffi::wasm_externtype_t);
+//         }
+//     }
+// }
+
+pub struct ExportTypeVec {
+    raw: ffi::wasm_exporttype_vec_t,
+}
+
+impl Deref for ExportTypeVec {
+    type Target = [ExportType];
+
+    fn deref(&self) -> &[ExportType] {
+        unsafe { slice::from_raw_parts(self.raw.data as *const ExportType, self.raw.size) }
+    }
+}
+
+impl Drop for ExportTypeVec {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::wasm_exporttype_vec_delete(&mut self.raw);
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct ExportType {
+    raw: *mut ffi::wasm_exporttype_t,
+}
+
+impl ExportType {
+    pub fn name(&self) -> &str {
+        unsafe { super::name_to_str(ffi::wasm_exporttype_name(self.raw)) }
+    }
+}
+
+impl Drop for ExportType {
+    fn drop(&mut self) {
+        eprintln!("drop export type");
+        panic!()
+        // unsafe {
+        //     ffi::wasm_exporttype_delete(self.raw);
+        // }
+    }
+}

--- a/jit/src/store.rs
+++ b/jit/src/store.rs
@@ -1,0 +1,25 @@
+use super::ffi;
+use super::Engine;
+
+#[repr(transparent)]
+pub struct Store {
+    pub(crate) raw: *mut ffi::wasm_store_t,
+}
+
+impl Store {
+    pub fn new(engine: &Engine) -> Store {
+        unsafe {
+            let raw = ffi::wasm_store_new(engine.raw);
+            assert!(!raw.is_null());
+            Store { raw }
+        }
+    }
+}
+
+impl Drop for Store {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::wasm_store_delete(self.raw);
+        }
+    }
+}

--- a/jit/src/trap.rs
+++ b/jit/src/trap.rs
@@ -1,0 +1,57 @@
+use super::ffi;
+use std::fmt;
+use std::mem;
+
+#[repr(transparent)]
+pub struct Trap {
+    pub(crate) raw: *mut ffi::wasm_trap_t,
+}
+
+impl Trap {
+    pub fn message(&self) -> Message {
+        unsafe {
+            let mut raw = mem::zeroed();
+            ffi::wasm_trap_message(self.raw, &mut raw);
+            Message { raw }
+        }
+    }
+}
+
+impl fmt::Display for Trap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.message().as_str().fmt(f)
+    }
+}
+
+impl fmt::Debug for Trap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl Drop for Trap {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::wasm_trap_delete(self.raw);
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct Message {
+    pub(crate) raw: ffi::wasm_message_t,
+}
+
+impl Message {
+    pub fn as_str(&self) -> &str {
+        unsafe { super::name_to_str(&self.raw) }
+    }
+}
+
+impl Drop for Message {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::wasm_byte_vec_delete(&mut self.raw);
+        }
+    }
+}

--- a/jit/src/val.rs
+++ b/jit/src/val.rs
@@ -1,0 +1,76 @@
+use super::ffi;
+
+#[repr(transparent)]
+pub struct Val {
+    pub(crate) raw: ffi::wasm_val_t,
+}
+
+impl Val {
+    pub fn i32(val: i32) -> Val {
+        Val {
+            raw: ffi::wasm_val_t {
+                kind: ffi::WASM_I32,
+                of: ffi::wasm_val_t_union { i32: val },
+            },
+        }
+    }
+
+    // pub fn i64(val: i64) -> Val {
+    //     Val {
+    //         raw: ffi::wasm_val_t {
+    //             kind: ffi::WASM_I64,
+    //             of: ffi::wasm_val_t_union { i64: val },
+    //         },
+    //     }
+    // }
+    //
+    // pub fn f32(val: f32) -> Val {
+    //     Val {
+    //         raw: ffi::wasm_val_t {
+    //             kind: ffi::WASM_F32,
+    //             of: ffi::wasm_val_t_union { f32: val },
+    //         },
+    //     }
+    // }
+    //
+    // pub fn f64(val: f64) -> Val {
+    //     Val {
+    //         raw: ffi::wasm_val_t {
+    //             kind: ffi::WASM_F64,
+    //             of: ffi::wasm_val_t_union { f64: val },
+    //         },
+    //     }
+    // }
+
+    pub fn as_i32(&self) -> Option<i32> {
+        if self.raw.kind == ffi::WASM_I32 {
+            Some(unsafe { self.raw.of.i32 })
+        } else {
+            None
+        }
+    }
+
+    // pub fn as_i64(&self) -> Option<i64> {
+    //     if self.raw.kind == ffi::WASM_I64 {
+    //         Some(unsafe { self.raw.of.i64 })
+    //     } else {
+    //         None
+    //     }
+    // }
+    //
+    // pub fn as_f32(&self) -> Option<f32> {
+    //     if self.raw.kind == ffi::WASM_F32 {
+    //         Some(unsafe { self.raw.of.f32 })
+    //     } else {
+    //         None
+    //     }
+    // }
+    //
+    // pub fn as_f64(&self) -> Option<f64> {
+    //     if self.raw.kind == ffi::WASM_F64 {
+    //         Some(unsafe { self.raw.of.f64 })
+    //     } else {
+    //         None
+    //     }
+    // }
+}

--- a/jit/src/valtype.rs
+++ b/jit/src/valtype.rs
@@ -1,0 +1,75 @@
+use super::ffi;
+use std::mem;
+
+#[repr(transparent)]
+pub struct ValType {
+    pub(crate) raw: *mut ffi::wasm_valtype_t,
+}
+
+impl ValType {
+    pub fn i32() -> ValType {
+        ValType::new(ffi::WASM_I32)
+    }
+
+    pub fn i64() -> ValType {
+        ValType::new(ffi::WASM_I64)
+    }
+
+    pub fn f32() -> ValType {
+        ValType::new(ffi::WASM_F32)
+    }
+
+    pub fn f64() -> ValType {
+        ValType::new(ffi::WASM_F64)
+    }
+
+    fn new(kind: ffi::wasm_valkind_t) -> ValType {
+        unsafe {
+            let raw = ffi::wasm_valtype_new(kind);
+            assert!(!raw.is_null());
+            ValType { raw }
+        }
+    }
+}
+
+impl Drop for ValType {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::wasm_valtype_delete(self.raw);
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct ValTypeVec {
+    pub(crate) raw: ffi::wasm_valtype_vec_t,
+}
+
+impl ValTypeVec {
+    pub fn new(list: &[ValType]) -> ValTypeVec {
+        unsafe {
+            let mut raw = mem::zeroed();
+            ffi::wasm_valtype_vec_new(
+                &mut raw,
+                list.len(),
+                list.as_ptr() as *const *mut ffi::wasm_valtype_t,
+            );
+            ValTypeVec { raw }
+        }
+    }
+
+    // pub fn empty() -> ValTypeVec {
+    //     unsafe {
+    //         let mut raw = mem::zeroed();
+    //         ffi::wasm_valtype_vec_new_empty(&mut raw);
+    //         ValTypeVec { raw }
+    //     }
+    // }
+}
+
+impl Drop for ValTypeVec {
+    fn drop(&mut self) {
+        eprintln!("drop valtype vec");
+        panic!()
+    }
+}

--- a/runtime/src/func.rs
+++ b/runtime/src/func.rs
@@ -1,0 +1,104 @@
+use super::{HostFunc, Interpreter, Store, Value};
+
+pub trait WasmArg: Sized {
+    fn pop(interp: &mut Interpreter) -> Self;
+    fn push(interp: &mut Interpreter, val: Self);
+}
+
+macro_rules! wasmarg {
+    ($($a:ident/$variant:ident)*) => ($(
+        impl WasmArg for $a {
+            fn pop(interp: &mut Interpreter) -> Self {
+                match interp.pop().unwrap() {
+                    Value::$variant(v) => v,
+                    _ => panic!("unexpected value"),
+                }
+            }
+
+            fn push(interp: &mut Interpreter, val: Self) {
+                interp.push(Value::$variant(val));
+            }
+        }
+    )*)
+}
+
+wasmarg! {
+    u32/I32
+    u64/I64
+    f32/F32
+    f64/F64
+}
+
+macro_rules! wasmarg_as {
+    ($($a:ident as $b:ident)*) => ($(
+        impl WasmArg for $b {
+            fn pop(interp: &mut Interpreter) -> Self {
+                <$a as WasmArg>::pop(interp) as $b
+            }
+
+            fn push(interp: &mut Interpreter, val: Self) {
+                <$a as WasmArg>::push(interp, val as $a)
+            }
+        }
+    )*)
+}
+
+wasmarg_as! {
+    u32 as i32
+    u64 as i64
+}
+
+impl WasmArg for () {
+    fn pop(interp: &mut Interpreter) -> Self {
+        drop(interp);
+    }
+    fn push(interp: &mut Interpreter, val: Self) {
+        drop((interp, val));
+    }
+}
+
+impl WasmArg for *mut [u8] {
+    fn pop(interp: &mut Interpreter) -> *mut [u8] {
+        interp.get_memory_mut()
+    }
+    fn push(_interp: &mut Interpreter, _val: Self) {
+        unreachable!();
+    }
+}
+
+macro_rules! reverse {
+    () => ();
+    ($a:stmt; $($b:tt)*) => (
+        reverse!($($b)*);
+        $a;
+    );
+}
+
+macro_rules! fnimpl {
+    ($traitname:ident $($arg:ident)*) => (
+        pub trait $traitname<$($arg),*> {
+            fn into_host_func(self, _store: &Store) -> HostFunc;
+        }
+
+        #[allow(non_snake_case)]
+        impl<F, R, $($arg: WasmArg),*> $traitname<$($arg),*> for F
+        where
+            F: Fn($($arg),*) -> R + 'static,
+            R: WasmArg,
+        {
+            fn into_host_func(self, _store: &Store) -> HostFunc {
+                return Box::new(move |interp| {
+                    reverse!($(let $arg = <$arg as WasmArg>::pop(interp);)*);
+                    let ret = self($($arg),*);
+                    <R as WasmArg>::push(interp, ret);
+                    None
+                });
+            }
+        }
+    );
+}
+
+fnimpl!(WasmFunc0);
+fnimpl!(WasmFunc1 A);
+fnimpl!(WasmFunc2 A B);
+fnimpl!(WasmFunc3 A B C);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod interpreter;
 pub mod ast;
 mod binary;
+pub mod func;
 pub mod ops;
 pub mod runtime;
 pub mod types;
@@ -17,6 +18,7 @@ mod valid;
 pub mod values;
 
 pub use self::ast::Module;
+pub use self::func::{WasmFunc0, WasmFunc1, WasmFunc2, WasmFunc3};
 pub use self::interpreter::Interpreter;
 pub use self::runtime::{ExternVal, HostFunc};
 pub use self::types::Extern;

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,6 +1,24 @@
-use crate::runtime::{module_exports, module_imports, Module};
+use crate::runtime::Module;
 
+#[cfg(jit)]
+pub fn print_module(_module: &Module) {
+    // let mut imports: Vec<_> = module_imports(module).collect();
+    // imports.sort_by_key(|entry| entry.1);
+    // for (_env, name, sig) in imports {
+    //     eprintln!("IMPORT {:?}: {:?}", name, sig);
+    // }
+    //
+    // let mut exports: Vec<_> = module_exports(module).collect();
+    // exports.sort_by_key(|entry| entry.0);
+    // for (name, sig) in exports {
+    //     eprintln!("EXPORT {:?}: {:?}", name, sig);
+    // }
+}
+
+#[cfg(not(jit))]
 pub fn print_module(module: &Module) {
+    use crate::runtime::{module_exports, module_imports};
+
     let mut imports: Vec<_> = module_imports(module).collect();
     imports.sort_by_key(|entry| entry.1);
     for (_env, name, sig) in imports {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,12 +1,55 @@
 use crate::data::Data;
-use crate::runtime::{
-    decode_module, get_export, init_store, instantiate_module, invoke_func, ExternVal, Value,
-};
 use crate::{debug, import};
 use proc_macro::TokenStream;
-use std::io::Cursor;
 
 pub fn proc_macro(fun: &str, inputs: Vec<TokenStream>, wasm: &[u8]) -> TokenStream {
+    _proc_macro(fun, inputs, wasm)
+}
+
+#[cfg(jit)]
+fn _proc_macro(fun: &str, inputs: Vec<TokenStream>, wasm: &[u8]) -> TokenStream {
+    use crate::runtime::*;
+
+    let engine = Engine::new();
+    let mut store = Store::new(&engine);
+    let module = Module::new(&store, wasm);
+    if cfg!(watt_debug) {
+        debug::print_module(&module);
+    }
+    let imports = import::extern_vals(&module, &mut store);
+    let module_instance = Instance::new(&store, &module, &imports).unwrap();
+    let main = module
+        .exports()
+        .iter()
+        .position(|p| p.name() == fun)
+        .unwrap();
+    let exports = module_instance.exports();
+    let main = exports[main].func().unwrap();
+    let memory = exports.iter().filter_map(|e| e.memory()).next().unwrap();
+
+    let _guard = Data::guard();
+    let args = Data::with(|d| {
+        inputs
+            .into_iter()
+            .map(|input| Val::i32(d.tokenstream.push(input) as i32))
+            .collect::<Vec<_>>()
+    });
+
+    current_memory::set(&memory, || {
+        let values = main.call(&args).unwrap();
+        let handle = values.into_iter().next().unwrap();
+        let handle = handle.as_i32().unwrap() as u32;
+        Data::with(|d| d.tokenstream[handle].clone())
+    })
+}
+
+#[cfg(not(jit))]
+fn _proc_macro(fun: &str, inputs: Vec<TokenStream>, wasm: &[u8]) -> TokenStream {
+    use crate::runtime::{
+        decode_module, get_export, init_store, instantiate_module, invoke_func, ExternVal, Value,
+    };
+    use std::io::Cursor;
+
     let cursor = Cursor::new(wasm);
     let module = decode_module(cursor).unwrap();
     if cfg!(watt_debug) {

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,132 +1,163 @@
-use crate::runtime::{alloc_func, module_imports, Extern, ExternVal, HostFunc, Module, Store};
+use crate::runtime::{Module, Store};
 use crate::sym;
 
-type Import<'a> = (&'a str, &'a str, Extern);
+#[cfg(jit)]
+use crate::runtime::Func as HostFunc;
+#[cfg(not(jit))]
+use crate::runtime::HostFunc;
 
-pub fn extern_vals(module: &Module, store: &mut Store) -> Vec<ExternVal> {
-    module_imports(module)
-        .map(|import| resolve(import, store))
-        .collect()
+#[cfg(jit)]
+pub fn extern_vals(module: &Module, store: &mut Store) -> crate::runtime::InstanceImports {
+    use crate::runtime::{ImportType, InstanceImports};
+
+    let mut imports = InstanceImports::default();
+    for import in module.imports().iter() {
+        imports.func(mk_host_func(import, store));
+    }
+    return imports;
+
+    fn mk_host_func(import: &ImportType, store: &Store) -> HostFunc {
+        // TODO: assert `import` is a function import
+        assert_eq!(import.module(), "env");
+        host_func(import.name(), store)
+    }
 }
 
-fn resolve(import: Import, store: &mut Store) -> ExternVal {
-    let (_module, name, sig) = import;
-    let func = match sig {
-        Extern::Func(func) => func,
-        Extern::Table(_) | Extern::Memory(_) | Extern::Global(_) => {
-            unimplemented!("unsupported import")
-        }
-    };
-    let hostfunc: HostFunc = match name {
-        "token_stream_new" => Box::new(sym::token_stream_new),
-        "token_stream_is_empty" => Box::new(sym::token_stream_is_empty),
-        "token_stream_from_str" => Box::new(sym::token_stream_from_str),
-        "token_stream_into_iter" => Box::new(sym::token_stream_into_iter),
-        "token_stream_iter_next" => Box::new(sym::token_stream_iter_next),
-        "token_stream_from_group" => Box::new(sym::token_stream_from_group),
-        "token_stream_from_ident" => Box::new(sym::token_stream_from_ident),
-        "token_stream_from_punct" => Box::new(sym::token_stream_from_punct),
-        "token_stream_from_literal" => Box::new(sym::token_stream_from_literal),
-        "token_stream_push_group" => Box::new(sym::token_stream_push_group),
-        "token_stream_push_ident" => Box::new(sym::token_stream_push_ident),
-        "token_stream_push_punct" => Box::new(sym::token_stream_push_punct),
-        "token_stream_push_literal" => Box::new(sym::token_stream_push_literal),
-        "token_stream_extend" => Box::new(sym::token_stream_extend),
+#[cfg(not(jit))]
+pub fn extern_vals(module: &Module, store: &mut Store) -> Vec<crate::runtime::ExternVal> {
+    use crate::runtime::{alloc_func, Extern, ExternVal};
 
-        "token_tree_kind" => Box::new(sym::token_tree_kind),
-        "token_tree_unwrap_group" => Box::new(sym::token_tree_unwrap_group),
-        "token_tree_unwrap_ident" => Box::new(sym::token_tree_unwrap_ident),
-        "token_tree_unwrap_punct" => Box::new(sym::token_tree_unwrap_punct),
-        "token_tree_unwrap_literal" => Box::new(sym::token_tree_unwrap_literal),
+    type Import<'a> = (&'a str, &'a str, Extern);
 
-        "span_call_site" => Box::new(sym::span_call_site),
+    return crate::runtime::module_imports(module)
+        .map(|import| mk_host_func(import, store))
+        .collect();
 
-        "group_new" => Box::new(sym::group_new),
-        "group_delimiter" => Box::new(sym::group_delimiter),
-        "group_stream" => Box::new(sym::group_stream),
-        "group_span" => Box::new(sym::group_span),
-        "group_set_span" => Box::new(sym::group_set_span),
+    fn mk_host_func(import: Import, store: &mut Store) -> ExternVal {
+        let (_module, name, ref sig) = import;
+        let func = match sig {
+            Extern::Func(func) => func,
+            Extern::Table(_) | Extern::Memory(_) | Extern::Global(_) => {
+                unimplemented!("unsupported import")
+            }
+        };
+        let hostfunc = host_func(name, store);
+        ExternVal::Func(alloc_func(store, &func, hostfunc))
+    }
+}
 
-        "punct_new" => Box::new(sym::punct_new),
-        "punct_as_char" => Box::new(sym::punct_as_char),
-        "punct_spacing" => Box::new(sym::punct_spacing),
-        "punct_span" => Box::new(sym::punct_span),
-        "punct_set_span" => Box::new(sym::punct_set_span),
+fn host_func(name: &str, store: &Store) -> HostFunc {
+    use crate::runtime::{WasmFunc0, WasmFunc1, WasmFunc2, WasmFunc3};
 
-        "ident_new" => Box::new(sym::ident_new),
-        "ident_span" => Box::new(sym::ident_span),
-        "ident_set_span" => Box::new(sym::ident_set_span),
-        "ident_eq" => Box::new(sym::ident_eq),
-        "ident_eq_str" => Box::new(sym::ident_eq_str),
-        "ident_cmp" => Box::new(sym::ident_cmp),
+    match name {
+        "token_stream_new" => sym::token_stream_new.into_host_func(store),
+        "token_stream_is_empty" => sym::token_stream_is_empty.into_host_func(store),
+        "token_stream_from_str" => sym::token_stream_from_str.into_host_func(store),
+        "token_stream_into_iter" => sym::token_stream_into_iter.into_host_func(store),
+        "token_stream_iter_next" => sym::token_stream_iter_next.into_host_func(store),
+        "token_stream_from_group" => sym::token_stream_from_group.into_host_func(store),
+        "token_stream_from_ident" => sym::token_stream_from_ident.into_host_func(store),
+        "token_stream_from_punct" => sym::token_stream_from_punct.into_host_func(store),
+        "token_stream_from_literal" => sym::token_stream_from_literal.into_host_func(store),
+        "token_stream_push_group" => sym::token_stream_push_group.into_host_func(store),
+        "token_stream_push_ident" => sym::token_stream_push_ident.into_host_func(store),
+        "token_stream_push_punct" => sym::token_stream_push_punct.into_host_func(store),
+        "token_stream_push_literal" => sym::token_stream_push_literal.into_host_func(store),
+        "token_stream_extend" => sym::token_stream_extend.into_host_func(store),
 
-        "literal_u8_suffixed" => Box::new(sym::literal_u8_suffixed),
-        "literal_u16_suffixed" => Box::new(sym::literal_u16_suffixed),
-        "literal_u32_suffixed" => Box::new(sym::literal_u32_suffixed),
-        "literal_u64_suffixed" => Box::new(sym::literal_u64_suffixed),
-        "literal_u128_suffixed" => Box::new(sym::literal_u128_suffixed),
-        "literal_usize_suffixed" => Box::new(sym::literal_usize_suffixed),
-        "literal_i8_suffixed" => Box::new(sym::literal_i8_suffixed),
-        "literal_i16_suffixed" => Box::new(sym::literal_i16_suffixed),
-        "literal_i32_suffixed" => Box::new(sym::literal_i32_suffixed),
-        "literal_i64_suffixed" => Box::new(sym::literal_i64_suffixed),
-        "literal_i128_suffixed" => Box::new(sym::literal_i128_suffixed),
-        "literal_isize_suffixed" => Box::new(sym::literal_isize_suffixed),
-        "literal_u8_unsuffixed" => Box::new(sym::literal_u8_unsuffixed),
-        "literal_u16_unsuffixed" => Box::new(sym::literal_u16_unsuffixed),
-        "literal_u32_unsuffixed" => Box::new(sym::literal_u32_unsuffixed),
-        "literal_u64_unsuffixed" => Box::new(sym::literal_u64_unsuffixed),
-        "literal_u128_unsuffixed" => Box::new(sym::literal_u128_unsuffixed),
-        "literal_usize_unsuffixed" => Box::new(sym::literal_usize_unsuffixed),
-        "literal_i8_unsuffixed" => Box::new(sym::literal_i8_unsuffixed),
-        "literal_i16_unsuffixed" => Box::new(sym::literal_i16_unsuffixed),
-        "literal_i32_unsuffixed" => Box::new(sym::literal_i32_unsuffixed),
-        "literal_i64_unsuffixed" => Box::new(sym::literal_i64_unsuffixed),
-        "literal_i128_unsuffixed" => Box::new(sym::literal_i128_unsuffixed),
-        "literal_isize_unsuffixed" => Box::new(sym::literal_isize_unsuffixed),
-        "literal_f64_unsuffixed" => Box::new(sym::literal_f64_unsuffixed),
-        "literal_f64_suffixed" => Box::new(sym::literal_f64_suffixed),
-        "literal_f32_unsuffixed" => Box::new(sym::literal_f32_unsuffixed),
-        "literal_f32_suffixed" => Box::new(sym::literal_f32_suffixed),
-        "literal_string" => Box::new(sym::literal_string),
-        "literal_character" => Box::new(sym::literal_character),
-        "literal_byte_string" => Box::new(sym::literal_byte_string),
-        "literal_span" => Box::new(sym::literal_span),
-        "literal_set_span" => Box::new(sym::literal_set_span),
+        "token_tree_kind" => sym::token_tree_kind.into_host_func(store),
+        "token_tree_unwrap_group" => sym::token_tree_unwrap_group.into_host_func(store),
+        "token_tree_unwrap_ident" => sym::token_tree_unwrap_ident.into_host_func(store),
+        "token_tree_unwrap_punct" => sym::token_tree_unwrap_punct.into_host_func(store),
+        "token_tree_unwrap_literal" => sym::token_tree_unwrap_literal.into_host_func(store),
 
-        "token_stream_clone" => Box::new(sym::token_stream_clone),
-        "group_clone" => Box::new(sym::group_clone),
-        "ident_clone" => Box::new(sym::ident_clone),
-        "punct_clone" => Box::new(sym::punct_clone),
-        "literal_clone" => Box::new(sym::literal_clone),
-        "token_stream_iter_clone" => Box::new(sym::token_stream_iter_clone),
+        "span_call_site" => sym::span_call_site.into_host_func(store),
 
-        "token_stream_to_string" => Box::new(sym::token_stream_to_string),
-        "group_to_string" => Box::new(sym::group_to_string),
-        "ident_to_string" => Box::new(sym::ident_to_string),
-        "punct_to_string" => Box::new(sym::punct_to_string),
-        "literal_to_string" => Box::new(sym::literal_to_string),
-        "token_stream_debug" => Box::new(sym::token_stream_debug),
-        "group_debug" => Box::new(sym::group_debug),
-        "ident_debug" => Box::new(sym::ident_debug),
-        "punct_debug" => Box::new(sym::punct_debug),
-        "literal_debug" => Box::new(sym::literal_debug),
-        "span_debug" => Box::new(sym::span_debug),
+        "group_new" => sym::group_new.into_host_func(store),
+        "group_delimiter" => sym::group_delimiter.into_host_func(store),
+        "group_stream" => sym::group_stream.into_host_func(store),
+        "group_span" => sym::group_span.into_host_func(store),
+        "group_set_span" => sym::group_set_span.into_host_func(store),
 
-        "watt_string_new" => Box::new(sym::watt_string_new),
-        "watt_string_len" => Box::new(sym::watt_string_len),
-        "watt_string_read" => Box::new(sym::watt_string_read),
-        "watt_bytes_new" => Box::new(sym::watt_bytes_new),
-        "watt_print_panic" => Box::new(sym::watt_print_panic),
+        "punct_new" => sym::punct_new.into_host_func(store),
+        "punct_as_char" => sym::punct_as_char.into_host_func(store),
+        "punct_spacing" => sym::punct_spacing.into_host_func(store),
+        "punct_span" => sym::punct_span.into_host_func(store),
+        "punct_set_span" => sym::punct_set_span.into_host_func(store),
+
+        "ident_new" => sym::ident_new.into_host_func(store),
+        "ident_span" => sym::ident_span.into_host_func(store),
+        "ident_set_span" => sym::ident_set_span.into_host_func(store),
+        "ident_eq" => sym::ident_eq.into_host_func(store),
+        "ident_eq_str" => sym::ident_eq_str.into_host_func(store),
+        "ident_cmp" => sym::ident_cmp.into_host_func(store),
+
+        "literal_u8_suffixed" => sym::literal_u8_suffixed.into_host_func(store),
+        "literal_u16_suffixed" => sym::literal_u16_suffixed.into_host_func(store),
+        "literal_u32_suffixed" => sym::literal_u32_suffixed.into_host_func(store),
+        "literal_u64_suffixed" => sym::literal_u64_suffixed.into_host_func(store),
+        "literal_u128_suffixed" => sym::literal_u128_suffixed.into_host_func(store),
+        "literal_usize_suffixed" => sym::literal_usize_suffixed.into_host_func(store),
+        "literal_i8_suffixed" => sym::literal_i8_suffixed.into_host_func(store),
+        "literal_i16_suffixed" => sym::literal_i16_suffixed.into_host_func(store),
+        "literal_i32_suffixed" => sym::literal_i32_suffixed.into_host_func(store),
+        "literal_i64_suffixed" => sym::literal_i64_suffixed.into_host_func(store),
+        "literal_i128_suffixed" => sym::literal_i128_suffixed.into_host_func(store),
+        "literal_isize_suffixed" => sym::literal_isize_suffixed.into_host_func(store),
+        "literal_u8_unsuffixed" => sym::literal_u8_unsuffixed.into_host_func(store),
+        "literal_u16_unsuffixed" => sym::literal_u16_unsuffixed.into_host_func(store),
+        "literal_u32_unsuffixed" => sym::literal_u32_unsuffixed.into_host_func(store),
+        "literal_u64_unsuffixed" => sym::literal_u64_unsuffixed.into_host_func(store),
+        "literal_u128_unsuffixed" => sym::literal_u128_unsuffixed.into_host_func(store),
+        "literal_usize_unsuffixed" => sym::literal_usize_unsuffixed.into_host_func(store),
+        "literal_i8_unsuffixed" => sym::literal_i8_unsuffixed.into_host_func(store),
+        "literal_i16_unsuffixed" => sym::literal_i16_unsuffixed.into_host_func(store),
+        "literal_i32_unsuffixed" => sym::literal_i32_unsuffixed.into_host_func(store),
+        "literal_i64_unsuffixed" => sym::literal_i64_unsuffixed.into_host_func(store),
+        "literal_i128_unsuffixed" => sym::literal_i128_unsuffixed.into_host_func(store),
+        "literal_isize_unsuffixed" => sym::literal_isize_unsuffixed.into_host_func(store),
+        "literal_f64_unsuffixed" => sym::literal_f64_unsuffixed.into_host_func(store),
+        "literal_f64_suffixed" => sym::literal_f64_suffixed.into_host_func(store),
+        "literal_f32_unsuffixed" => sym::literal_f32_unsuffixed.into_host_func(store),
+        "literal_f32_suffixed" => sym::literal_f32_suffixed.into_host_func(store),
+        "literal_string" => sym::literal_string.into_host_func(store),
+        "literal_character" => sym::literal_character.into_host_func(store),
+        "literal_byte_string" => sym::literal_byte_string.into_host_func(store),
+        "literal_span" => sym::literal_span.into_host_func(store),
+        "literal_set_span" => sym::literal_set_span.into_host_func(store),
+
+        "token_stream_clone" => sym::token_stream_clone.into_host_func(store),
+        "group_clone" => sym::group_clone.into_host_func(store),
+        "ident_clone" => sym::ident_clone.into_host_func(store),
+        "punct_clone" => sym::punct_clone.into_host_func(store),
+        "literal_clone" => sym::literal_clone.into_host_func(store),
+        "token_stream_iter_clone" => sym::token_stream_iter_clone.into_host_func(store),
+
+        "token_stream_to_string" => sym::token_stream_to_string.into_host_func(store),
+        "group_to_string" => sym::group_to_string.into_host_func(store),
+        "ident_to_string" => sym::ident_to_string.into_host_func(store),
+        "punct_to_string" => sym::punct_to_string.into_host_func(store),
+        "literal_to_string" => sym::literal_to_string.into_host_func(store),
+        "token_stream_debug" => sym::token_stream_debug.into_host_func(store),
+        "group_debug" => sym::group_debug.into_host_func(store),
+        "ident_debug" => sym::ident_debug.into_host_func(store),
+        "punct_debug" => sym::punct_debug.into_host_func(store),
+        "literal_debug" => sym::literal_debug.into_host_func(store),
+        "span_debug" => sym::span_debug.into_host_func(store),
+
+        "watt_string_new" => sym::watt_string_new.into_host_func(store),
+        "watt_string_len" => sym::watt_string_len.into_host_func(store),
+        "watt_string_read" => sym::watt_string_read.into_host_func(store),
+        "watt_bytes_new" => sym::watt_bytes_new.into_host_func(store),
+        "watt_print_panic" => sym::watt_print_panic.into_host_func(store),
 
         // to be removed in 0.2
-        "watt_string_with_capacity" => Box::new(sym::watt_string_with_capacity),
-        "watt_string_push_char" => Box::new(sym::watt_string_push_char),
-        "watt_string_char_at" => Box::new(sym::watt_string_char_at),
-        "watt_bytes_with_capacity" => Box::new(sym::watt_bytes_with_capacity),
-        "watt_bytes_push" => Box::new(sym::watt_bytes_push),
+        "watt_string_with_capacity" => sym::watt_string_with_capacity.into_host_func(store),
+        "watt_string_push_char" => sym::watt_string_push_char.into_host_func(store),
+        "watt_string_char_at" => sym::watt_string_char_at.into_host_func(store),
+        "watt_bytes_with_capacity" => sym::watt_bytes_with_capacity.into_host_func(store),
+        "watt_bytes_push" => sym::watt_bytes_push.into_host_func(store),
 
         _ => unreachable!("unresolved import: {:?}", name),
-    };
-    ExternVal::Func(alloc_func(store, &func, hostfunc))
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,11 @@
 
 extern crate proc_macro;
 
+#[cfg(not(jit))]
 #[path = "../runtime/src/lib.rs"]
+mod runtime;
+#[cfg(jit)]
+#[path = "../jit/src/lib.rs"]
 mod runtime;
 
 mod data;

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -1,5 +1,4 @@
 use crate::data::Data;
-use crate::runtime::{Interpreter, Value};
 use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 use std::char;
 use std::cmp::Ordering;
@@ -21,250 +20,181 @@ const ORDERING_LESS: u32 = 0;
 const ORDERING_EQUAL: u32 = 1;
 const ORDERING_GREATER: u32 = 2;
 
-// args: []
-// result: [Int(I32)]
-pub fn token_stream_new(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_new() -> u32 {
+    Data::with(|d| d.tokenstream.push(TokenStream::new()))
+}
+
+pub fn token_stream_is_empty(stream: u32) -> u32 {
     Data::with(|d| {
-        let stream = d.tokenstream.push(TokenStream::new());
-        interp.push(Value::I32(stream));
-        None
+        let stream = &d.tokenstream[stream];
+        stream.is_empty() as u32
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_stream_is_empty(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_from_str(string: u32) -> u32 {
     Data::with(|d| {
-        let stream = &d.tokenstream[pop(interp)];
-        let is_empty = stream.is_empty();
-        interp.push(Value::I32(is_empty as u32));
-        None
-    })
-}
-
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_stream_from_str(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let string = &d.string[pop(interp)];
+        let string = &d.string[string];
         let result = TokenStream::from_str(string);
-        interp.push(Value::I32(match result {
+        match result {
             Ok(stream) => d.tokenstream.push(stream),
             Err(_error) => SENTINEL,
-        }));
-        None
+        }
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_stream_into_iter(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_into_iter(stream: u32) -> u32 {
     Data::with(|d| {
-        let stream = &d.tokenstream[pop(interp)];
+        let stream = &d.tokenstream[stream];
         let iter = stream.clone().into_iter();
-        interp.push(Value::I32(d.intoiter.push(iter)));
-        None
+        d.intoiter.push(iter)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_stream_iter_next(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_iter_next(iter: u32) -> u32 {
     Data::with(|d| {
-        let iter = &mut d.intoiter[pop(interp)];
-        interp.push(Value::I32(match iter.next() {
+        let iter = &mut d.intoiter[iter];
+        match iter.next() {
             Some(token) => d.tokentree.push(token),
             None => SENTINEL,
-        }));
-        None
+        }
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_stream_from_group(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_from_group(group: u32) -> u32 {
     Data::with(|d| {
-        let group = &d.group[pop(interp)];
+        let group = &d.group[group];
         let tree = TokenTree::Group(group.clone());
-        interp.push(Value::I32(d.tokenstream.push(TokenStream::from(tree))));
-        None
+        d.tokenstream.push(TokenStream::from(tree))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_stream_from_ident(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_from_ident(ident: u32) -> u32 {
     Data::with(|d| {
-        let ident = &d.ident[pop(interp)];
+        let ident = &d.ident[ident];
         let tree = TokenTree::Ident(ident.clone());
-        interp.push(Value::I32(d.tokenstream.push(TokenStream::from(tree))));
-        None
+        d.tokenstream.push(TokenStream::from(tree))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_stream_from_punct(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_from_punct(punct: u32) -> u32 {
     Data::with(|d| {
-        let punct = &d.punct[pop(interp)];
+        let punct = &d.punct[punct];
         let tree = TokenTree::Punct(punct.clone());
-        interp.push(Value::I32(d.tokenstream.push(TokenStream::from(tree))));
-        None
+        d.tokenstream.push(TokenStream::from(tree))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_stream_from_literal(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_from_literal(literal: u32) -> u32 {
     Data::with(|d| {
-        let literal = &d.literal[pop(interp)];
+        let literal = &d.literal[literal];
         let tree = TokenTree::Literal(literal.clone());
-        interp.push(Value::I32(d.tokenstream.push(TokenStream::from(tree))));
-        None
+        d.tokenstream.push(TokenStream::from(tree))
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: []
-pub fn token_stream_push_group(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_push_group(stream: u32, group: u32) {
     Data::with(|d| {
-        let group = &d.group[pop(interp)];
-        let stream = &mut d.tokenstream[pop(interp)];
+        let group = &d.group[group];
+        let stream = &mut d.tokenstream[stream];
         stream.extend(once(TokenTree::Group(group.clone())));
-        None
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: []
-pub fn token_stream_push_ident(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_push_ident(stream: u32, ident: u32) {
     Data::with(|d| {
-        let ident = &d.ident[pop(interp)];
-        let stream = &mut d.tokenstream[pop(interp)];
+        let ident = &d.ident[ident];
+        let stream = &mut d.tokenstream[stream];
         stream.extend(once(TokenTree::Ident(ident.clone())));
-        None
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: []
-pub fn token_stream_push_punct(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_push_punct(stream: u32, punct: u32) {
     Data::with(|d| {
-        let punct = &d.punct[pop(interp)];
-        let stream = &mut d.tokenstream[pop(interp)];
+        let punct = &d.punct[punct];
+        let stream = &mut d.tokenstream[stream];
         stream.extend(once(TokenTree::Punct(punct.clone())));
-        None
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: []
-pub fn token_stream_push_literal(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_push_literal(stream: u32, literal: u32) {
     Data::with(|d| {
-        let literal = &d.literal[pop(interp)];
-        let stream = &mut d.tokenstream[pop(interp)];
+        let literal = &d.literal[literal];
+        let stream = &mut d.tokenstream[stream];
         stream.extend(once(TokenTree::Literal(literal.clone())));
-        None
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: []
-pub fn token_stream_extend(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_extend(stream: u32, next: u32) {
     Data::with(|d| {
-        let next = d.tokenstream[pop(interp)].clone();
-        let stream = &mut d.tokenstream[pop(interp)];
+        let next = d.tokenstream[next].clone();
+        let stream = &mut d.tokenstream[stream];
         stream.extend(next);
-        None
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_tree_kind(interp: &mut Interpreter) -> Option<String> {
+pub fn token_tree_kind(token: u32) -> u32 {
     Data::with(|d| {
-        let token = &d.tokentree[pop(interp)];
-        interp.push(Value::I32(match token {
+        let token = &d.tokentree[token];
+        match token {
             TokenTree::Group(_) => TOKEN_GROUP,
             TokenTree::Ident(_) => TOKEN_IDENT,
             TokenTree::Punct(_) => TOKEN_PUNCT,
             TokenTree::Literal(_) => TOKEN_LITERAL,
-        }));
-        None
+        }
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_tree_unwrap_group(interp: &mut Interpreter) -> Option<String> {
+pub fn token_tree_unwrap_group(token: u32) -> u32 {
     Data::with(|d| {
-        let token = &d.tokentree[pop(interp)];
+        let token = &d.tokentree[token];
         let group = match token {
             TokenTree::Group(group) => group,
             _ => unreachable!(),
         };
-        interp.push(Value::I32(d.group.push(group.clone())));
-        None
+        d.group.push(group.clone())
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_tree_unwrap_ident(interp: &mut Interpreter) -> Option<String> {
+pub fn token_tree_unwrap_ident(token: u32) -> u32 {
     Data::with(|d| {
-        let token = &d.tokentree[pop(interp)];
+        let token = &d.tokentree[token];
         let ident = match token {
             TokenTree::Ident(ident) => ident,
             _ => unreachable!(),
         };
-        interp.push(Value::I32(d.ident.push(ident.clone())));
-        None
+        d.ident.push(ident.clone())
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_tree_unwrap_punct(interp: &mut Interpreter) -> Option<String> {
+pub fn token_tree_unwrap_punct(token: u32) -> u32 {
     Data::with(|d| {
-        let token = &d.tokentree[pop(interp)];
+        let token = &d.tokentree[token];
         let punct = match token {
             TokenTree::Punct(punct) => punct,
             _ => unreachable!(),
         };
-        interp.push(Value::I32(d.punct.push(punct.clone())));
-        None
+        d.punct.push(punct.clone())
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_tree_unwrap_literal(interp: &mut Interpreter) -> Option<String> {
+pub fn token_tree_unwrap_literal(token: u32) -> u32 {
     Data::with(|d| {
-        let token = &d.tokentree[pop(interp)];
+        let token = &d.tokentree[token];
         let literal = match token {
             TokenTree::Literal(literal) => literal,
             _ => unreachable!(),
         };
-        interp.push(Value::I32(d.literal.push(literal.clone())));
-        None
+        d.literal.push(literal.clone())
     })
 }
 
-// args: []
-// result: [Int(I32)]
-pub fn span_call_site(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        interp.push(Value::I32(d.span.push(Span::call_site())));
-        None
-    })
+pub fn span_call_site() -> u32 {
+    Data::with(|d| d.span.push(Span::call_site()))
 }
 
-// args: [Int(I32), Int(I32)]
-// result: [Int(I32)]
-pub fn group_new(interp: &mut Interpreter) -> Option<String> {
+pub fn group_new(delimiter: u32, stream: u32) -> u32 {
     Data::with(|d| {
-        let stream = &d.tokenstream[pop(interp)];
-        let delimiter = pop(interp);
+        let stream = &d.tokenstream[stream];
         let delimiter = if delimiter == DELIMITER_PARENTHESIS {
             Delimiter::Parenthesis
         } else if delimiter == DELIMITER_BRACE {
@@ -277,63 +207,48 @@ pub fn group_new(interp: &mut Interpreter) -> Option<String> {
             unreachable!()
         };
         let group = Group::new(delimiter, stream.clone());
-        interp.push(Value::I32(d.group.push(group)));
-        None
+        d.group.push(group)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn group_delimiter(interp: &mut Interpreter) -> Option<String> {
+pub fn group_delimiter(group: u32) -> u32 {
     Data::with(|d| {
-        let group = &d.group[pop(interp)];
-        interp.push(Value::I32(match group.delimiter() {
+        let group = &d.group[group];
+        match group.delimiter() {
             Delimiter::Parenthesis => DELIMITER_PARENTHESIS,
             Delimiter::Brace => DELIMITER_BRACE,
             Delimiter::Bracket => DELIMITER_BRACKET,
             Delimiter::None => DELIMITER_NONE,
-        }));
-        None
+        }
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn group_stream(interp: &mut Interpreter) -> Option<String> {
+pub fn group_stream(group: u32) -> u32 {
     Data::with(|d| {
-        let group = &d.group[pop(interp)];
-        interp.push(Value::I32(d.tokenstream.push(group.stream())));
-        None
+        let group = &d.group[group];
+        d.tokenstream.push(group.stream())
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn group_span(interp: &mut Interpreter) -> Option<String> {
+pub fn group_span(group: u32) -> u32 {
     Data::with(|d| {
-        let group = &d.group[pop(interp)];
-        interp.push(Value::I32(d.span.push(group.span())));
-        None
+        let group = &d.group[group];
+        d.span.push(group.span())
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: []
-pub fn group_set_span(interp: &mut Interpreter) -> Option<String> {
+pub fn group_set_span(group: u32, span: u32) {
     Data::with(|d| {
-        let span = d.span[pop(interp)];
-        let group = &mut d.group[pop(interp)];
+        let span = d.span[span];
+        let group = &mut d.group[group];
         group.set_span(span);
-        None
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: [Int(I32)]
-pub fn punct_new(interp: &mut Interpreter) -> Option<String> {
+pub fn punct_new(op: u32, spacing: u32) -> u32 {
     Data::with(|d| {
-        let spacing = pop(interp);
-        let op = pop(interp);
+        let spacing = spacing;
+        let op = op;
         let spacing = if spacing == SPACING_ALONE {
             Spacing::Alone
         } else if spacing == SPACING_JOINT {
@@ -342,768 +257,487 @@ pub fn punct_new(interp: &mut Interpreter) -> Option<String> {
             unreachable!()
         };
         let op = char::from_u32(op).unwrap();
-        interp.push(Value::I32(d.punct.push(Punct::new(op, spacing))));
-        None
+        d.punct.push(Punct::new(op, spacing))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn punct_as_char(interp: &mut Interpreter) -> Option<String> {
+pub fn punct_as_char(punct: u32) -> u32 {
     Data::with(|d| {
-        let punct = &d.punct[pop(interp)];
-        interp.push(Value::I32(punct.as_char() as u32));
-        None
+        let punct = &d.punct[punct];
+        punct.as_char() as u32
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn punct_spacing(interp: &mut Interpreter) -> Option<String> {
+pub fn punct_spacing(punct: u32) -> u32 {
     Data::with(|d| {
-        let punct = &d.punct[pop(interp)];
-        interp.push(Value::I32(match punct.spacing() {
+        let punct = &d.punct[punct];
+        match punct.spacing() {
             Spacing::Alone => SPACING_ALONE,
             Spacing::Joint => SPACING_JOINT,
-        }));
-        None
+        }
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn punct_span(interp: &mut Interpreter) -> Option<String> {
+pub fn punct_span(punct: u32) -> u32 {
     Data::with(|d| {
-        let punct = &d.punct[pop(interp)];
-        interp.push(Value::I32(d.span.push(punct.span())));
-        None
+        let punct = &d.punct[punct];
+        d.span.push(punct.span())
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: []
-pub fn punct_set_span(interp: &mut Interpreter) -> Option<String> {
+pub fn punct_set_span(punct: u32, span: u32) {
     Data::with(|d| {
-        let span = d.span[pop(interp)];
-        let punct = &mut d.punct[pop(interp)];
+        let span = d.span[span];
+        let punct = &mut d.punct[punct];
         punct.set_span(span);
-        None
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: [Int(I32)]
-pub fn ident_new(interp: &mut Interpreter) -> Option<String> {
+pub fn ident_new(string: u32, span: u32) -> u32 {
     Data::with(|d| {
-        let span = d.span[pop(interp)];
-        let string = &d.string[pop(interp)];
-        interp.push(Value::I32(d.ident.push(Ident::new(string, span))));
-        None
+        let span = d.span[span];
+        let string = &d.string[string];
+        d.ident.push(Ident::new(string, span))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn ident_span(interp: &mut Interpreter) -> Option<String> {
+pub fn ident_span(ident: u32) -> u32 {
     Data::with(|d| {
-        let ident = &d.ident[pop(interp)];
-        interp.push(Value::I32(d.span.push(ident.span())));
-        None
+        let ident = &d.ident[ident];
+        d.span.push(ident.span())
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: []
-pub fn ident_set_span(interp: &mut Interpreter) -> Option<String> {
+pub fn ident_set_span(ident: u32, span: u32) {
     Data::with(|d| {
-        let span = d.span[pop(interp)];
-        let ident = &mut d.ident[pop(interp)];
+        let span = d.span[span];
+        let ident = &mut d.ident[ident];
         ident.set_span(span);
-        None
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: [Int(I32)]
-pub fn ident_eq(interp: &mut Interpreter) -> Option<String> {
+pub fn ident_eq(ident: u32, other: u32) -> u32 {
     Data::with(|d| {
-        let other = &d.ident[pop(interp)];
-        let ident = &d.ident[pop(interp)];
+        let other = &d.ident[other];
+        let ident = &d.ident[ident];
         let eq = ident.to_string() == other.to_string();
-        interp.push(Value::I32(eq as u32));
-        None
+        eq as u32
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: [Int(I32)]
-pub fn ident_eq_str(interp: &mut Interpreter) -> Option<String> {
+pub fn ident_eq_str(ident: u32, other: u32) -> u32 {
     Data::with(|d| {
-        let other = &d.string[pop(interp)];
-        let ident = &d.ident[pop(interp)];
+        let other = &d.string[other];
+        let ident = &d.ident[ident];
         let eq = ident.to_string() == *other;
-        interp.push(Value::I32(eq as u32));
-        None
+        eq as u32
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: [Int(I32)]
-pub fn ident_cmp(interp: &mut Interpreter) -> Option<String> {
+pub fn ident_cmp(ident: u32, other: u32) -> u32 {
     Data::with(|d| {
-        let other = &d.ident[pop(interp)];
-        let ident = &d.ident[pop(interp)];
+        let other = &d.ident[other];
+        let ident = &d.ident[ident];
         let cmp = match ident.to_string().cmp(&other.to_string()) {
             Ordering::Less => ORDERING_LESS,
             Ordering::Equal => ORDERING_EQUAL,
             Ordering::Greater => ORDERING_GREATER,
         };
-        interp.push(Value::I32(cmp));
-        None
+        cmp
+    })
+}
+
+pub fn literal_u8_suffixed(n: u32) -> u32 {
+    Data::with(|d| {
+        let n = n as u8;
+        d.literal.push(Literal::u8_suffixed(n))
+    })
+}
+
+pub fn literal_u16_suffixed(n: u32) -> u32 {
+    Data::with(|d| {
+        let n = n as u16;
+        d.literal.push(Literal::u16_suffixed(n))
     })
 }
 
 // args: [Int(I32)]
 // result: [Int(I32)]
-pub fn literal_u8_suffixed(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let n = pop(interp) as u8;
-        interp.push(Value::I32(d.literal.push(Literal::u8_suffixed(n))));
-        None
-    })
+pub fn literal_u32_suffixed(n: u32) -> u32 {
+    Data::with(|d| d.literal.push(Literal::u32_suffixed(n)))
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_u16_suffixed(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let n = pop(interp) as u16;
-        interp.push(Value::I32(d.literal.push(Literal::u16_suffixed(n))));
-        None
-    })
+pub fn literal_u64_suffixed(n: u64) -> u32 {
+    Data::with(|d| d.literal.push(Literal::u64_suffixed(n)))
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_u32_suffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_u128_suffixed(lo: u64, hi: u64) -> u32 {
     Data::with(|d| {
-        let n = pop(interp);
-        interp.push(Value::I32(d.literal.push(Literal::u32_suffixed(n))));
-        None
-    })
-}
-
-// args: [Int(I64)]
-// result: [Int(I32)]
-pub fn literal_u64_suffixed(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let n = pop64(interp);
-        interp.push(Value::I32(d.literal.push(Literal::u64_suffixed(n))));
-        None
-    })
-}
-
-// args: [Int(I64), Int(I64)]
-// result: [Int(I32)]
-pub fn literal_u128_suffixed(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let hi = pop64(interp);
-        let lo = pop64(interp);
         let n = ((hi as u128) << 64) + lo as u128;
-        interp.push(Value::I32(d.literal.push(Literal::u128_suffixed(n))));
-        None
+        d.literal.push(Literal::u128_suffixed(n))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_usize_suffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_usize_suffixed(n: u32) -> u32 {
     Data::with(|d| {
-        let n = pop(interp) as usize;
-        interp.push(Value::I32(d.literal.push(Literal::usize_suffixed(n))));
-        None
+        let n = n as usize;
+        d.literal.push(Literal::usize_suffixed(n))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_i8_suffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_i8_suffixed(n: u32) -> u32 {
     Data::with(|d| {
-        let n = pop(interp) as i8;
-        interp.push(Value::I32(d.literal.push(Literal::i8_suffixed(n))));
-        None
+        let n = n as i8;
+        d.literal.push(Literal::i8_suffixed(n))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_i16_suffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_i16_suffixed(n: u32) -> u32 {
     Data::with(|d| {
-        let n = pop(interp) as i16;
-        interp.push(Value::I32(d.literal.push(Literal::i16_suffixed(n))));
-        None
+        let n = n as i16;
+        d.literal.push(Literal::i16_suffixed(n))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_i32_suffixed(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let n = pop(interp) as i32;
-        interp.push(Value::I32(d.literal.push(Literal::i32_suffixed(n))));
-        None
-    })
+pub fn literal_i32_suffixed(n: i32) -> u32 {
+    Data::with(|d| d.literal.push(Literal::i32_suffixed(n)))
 }
 
-// args: [Int(I64)]
-// result: [Int(I32)]
-pub fn literal_i64_suffixed(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let n = pop64(interp) as i64;
-        interp.push(Value::I32(d.literal.push(Literal::i64_suffixed(n))));
-        None
-    })
+pub fn literal_i64_suffixed(n: i64) -> u32 {
+    Data::with(|d| d.literal.push(Literal::i64_suffixed(n)))
 }
 
-// args: [Int(I64), Int(I64)]
-// result: [Int(I32)]
-pub fn literal_i128_suffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_i128_suffixed(lo: u64, hi: u64) -> u32 {
     Data::with(|d| {
-        let hi = pop64(interp);
-        let lo = pop64(interp);
         let n = (((hi as u128) << 64) + lo as u128) as i128;
-        interp.push(Value::I32(d.literal.push(Literal::i128_suffixed(n))));
-        None
+        d.literal.push(Literal::i128_suffixed(n))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_isize_suffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_isize_suffixed(n: i32) -> u32 {
     Data::with(|d| {
-        let n = pop(interp) as isize;
-        interp.push(Value::I32(d.literal.push(Literal::isize_suffixed(n))));
-        None
+        let n = n as isize;
+        d.literal.push(Literal::isize_suffixed(n))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_u8_unsuffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_u8_unsuffixed(n: u32) -> u32 {
     Data::with(|d| {
-        let n = pop(interp) as u8;
-        interp.push(Value::I32(d.literal.push(Literal::u8_unsuffixed(n))));
-        None
+        let n = n as u8;
+        d.literal.push(Literal::u8_unsuffixed(n))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_u16_unsuffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_u16_unsuffixed(n: u32) -> u32 {
     Data::with(|d| {
-        let n = pop(interp) as u16;
-        interp.push(Value::I32(d.literal.push(Literal::u16_unsuffixed(n))));
-        None
+        let n = n as u16;
+        d.literal.push(Literal::u16_unsuffixed(n))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_u32_unsuffixed(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let n = pop(interp);
-        interp.push(Value::I32(d.literal.push(Literal::u32_unsuffixed(n))));
-        None
-    })
+pub fn literal_u32_unsuffixed(n: u32) -> u32 {
+    Data::with(|d| d.literal.push(Literal::u32_unsuffixed(n)))
 }
 
-// args: [Int(I64)]
-// result: [Int(I32)]
-pub fn literal_u64_unsuffixed(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let n = pop64(interp);
-        interp.push(Value::I32(d.literal.push(Literal::u64_unsuffixed(n))));
-        None
-    })
+pub fn literal_u64_unsuffixed(n: u64) -> u32 {
+    Data::with(|d| d.literal.push(Literal::u64_unsuffixed(n)))
 }
 
-// args: [Int(I64), Int(I64)]
-// result: [Int(I32)]
-pub fn literal_u128_unsuffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_u128_unsuffixed(lo: u64, hi: u64) -> u32 {
     Data::with(|d| {
-        let hi = pop64(interp);
-        let lo = pop64(interp);
         let n = ((hi as u128) << 64) + lo as u128;
-        interp.push(Value::I32(d.literal.push(Literal::u128_unsuffixed(n))));
-        None
+        d.literal.push(Literal::u128_unsuffixed(n))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_usize_unsuffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_usize_unsuffixed(n: u32) -> u32 {
     Data::with(|d| {
-        let n = pop(interp) as usize;
-        interp.push(Value::I32(d.literal.push(Literal::usize_unsuffixed(n))));
-        None
+        let n = n as usize;
+        d.literal.push(Literal::usize_unsuffixed(n))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_i8_unsuffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_i8_unsuffixed(n: u32) -> u32 {
     Data::with(|d| {
-        let n = pop(interp) as i8;
-        interp.push(Value::I32(d.literal.push(Literal::i8_unsuffixed(n))));
-        None
+        let n = n as i8;
+        d.literal.push(Literal::i8_unsuffixed(n))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_i16_unsuffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_i16_unsuffixed(n: u32) -> u32 {
     Data::with(|d| {
-        let n = pop(interp) as i16;
-        interp.push(Value::I32(d.literal.push(Literal::i16_unsuffixed(n))));
-        None
+        let n = n as i16;
+        d.literal.push(Literal::i16_unsuffixed(n))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_i32_unsuffixed(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let n = pop(interp) as i32;
-        interp.push(Value::I32(d.literal.push(Literal::i32_unsuffixed(n))));
-        None
-    })
+pub fn literal_i32_unsuffixed(n: i32) -> u32 {
+    Data::with(|d| d.literal.push(Literal::i32_unsuffixed(n)))
 }
 
-// args: [Int(I64)]
-// result: [Int(I32)]
-pub fn literal_i64_unsuffixed(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let n = pop64(interp) as i64;
-        interp.push(Value::I32(d.literal.push(Literal::i64_unsuffixed(n))));
-        None
-    })
+pub fn literal_i64_unsuffixed(n: i64) -> u32 {
+    Data::with(|d| d.literal.push(Literal::i64_unsuffixed(n)))
 }
 
-// args: [Int(I64), Int(I64)]
-// result: [Int(I32)]
-pub fn literal_i128_unsuffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_i128_unsuffixed(lo: u64, hi: u64) -> u32 {
     Data::with(|d| {
-        let hi = pop64(interp);
-        let lo = pop64(interp);
         let n = (((hi as u128) << 64) + lo as u128) as i128;
-        interp.push(Value::I32(d.literal.push(Literal::i128_unsuffixed(n))));
-        None
+        d.literal.push(Literal::i128_unsuffixed(n))
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_isize_unsuffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_isize_unsuffixed(n: i32) -> u32 {
     Data::with(|d| {
-        let n = pop(interp) as isize;
-        interp.push(Value::I32(d.literal.push(Literal::isize_unsuffixed(n))));
-        None
+        let n = n as isize;
+        d.literal.push(Literal::isize_unsuffixed(n))
     })
 }
 
-// args: [Int(F64)]
-// result: [Int(I32)]
-pub fn literal_f64_unsuffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_f64_unsuffixed(f: f64) -> u32 {
+    Data::with(|d| d.literal.push(Literal::f64_unsuffixed(f)))
+}
+
+pub fn literal_f64_suffixed(f: f64) -> u32 {
+    Data::with(|d| d.literal.push(Literal::f64_suffixed(f)))
+}
+
+pub fn literal_f32_unsuffixed(f: f32) -> u32 {
+    Data::with(|d| d.literal.push(Literal::f32_unsuffixed(f)))
+}
+
+pub fn literal_f32_suffixed(f: f32) -> u32 {
+    Data::with(|d| d.literal.push(Literal::f32_suffixed(f)))
+}
+
+pub fn literal_string(string: u32) -> u32 {
     Data::with(|d| {
-        let f = popf64(interp);
-        interp.push(Value::I32(d.literal.push(Literal::f64_unsuffixed(f))));
-        None
+        let string = &d.string[string];
+        d.literal.push(Literal::string(string))
     })
 }
 
-// args: [Int(F64)]
-// result: [Int(I32)]
-pub fn literal_f64_suffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_character(ch: u32) -> u32 {
     Data::with(|d| {
-        let f = popf64(interp);
-        interp.push(Value::I32(d.literal.push(Literal::f64_suffixed(f))));
-        None
+        let ch = char::from_u32(ch).unwrap();
+        d.literal.push(Literal::character(ch))
     })
 }
 
-// args: [Int(F32)]
-// result: [Int(I32)]
-pub fn literal_f32_unsuffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_byte_string(bytes: u32) -> u32 {
     Data::with(|d| {
-        let f = popf(interp);
-        interp.push(Value::I32(d.literal.push(Literal::f32_unsuffixed(f))));
-        None
+        let bytes = &d.bytes[bytes];
+        d.literal.push(Literal::byte_string(bytes))
     })
 }
 
-// args: [Int(F32)]
-// result: [Int(I32)]
-pub fn literal_f32_suffixed(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_span(literal: u32) -> u32 {
     Data::with(|d| {
-        let f = popf(interp);
-        interp.push(Value::I32(d.literal.push(Literal::f32_suffixed(f))));
-        None
+        let literal = &d.literal[literal];
+        d.span.push(literal.span())
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_string(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_set_span(literal: u32, span: u32) {
     Data::with(|d| {
-        let string = &d.string[pop(interp)];
-        interp.push(Value::I32(d.literal.push(Literal::string(string))));
-        None
-    })
-}
-
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_character(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let ch = char::from_u32(pop(interp)).unwrap();
-        interp.push(Value::I32(d.literal.push(Literal::character(ch))));
-        None
-    })
-}
-
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_byte_string(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let bytes = &d.bytes[pop(interp)];
-        interp.push(Value::I32(d.literal.push(Literal::byte_string(bytes))));
-        None
-    })
-}
-
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_span(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let literal = &d.literal[pop(interp)];
-        interp.push(Value::I32(d.span.push(literal.span())));
-        None
-    })
-}
-
-// args: [Int(I32), Int(I32)]
-// result: []
-pub fn literal_set_span(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| {
-        let span = d.span[pop(interp)];
-        let literal = &mut d.literal[pop(interp)];
+        let span = d.span[span];
+        let literal = &mut d.literal[literal];
         literal.set_span(span);
-        None
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_stream_clone(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_clone(stream: u32) -> u32 {
     Data::with(|d| {
-        let clone = d.tokenstream[pop(interp)].clone();
-        interp.push(Value::I32(d.tokenstream.push(clone)));
-        None
+        let clone = d.tokenstream[stream].clone();
+        d.tokenstream.push(clone)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn group_clone(interp: &mut Interpreter) -> Option<String> {
+pub fn group_clone(group: u32) -> u32 {
     Data::with(|d| {
-        let clone = d.group[pop(interp)].clone();
-        interp.push(Value::I32(d.group.push(clone)));
-        None
+        let clone = d.group[group].clone();
+        d.group.push(clone)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn ident_clone(interp: &mut Interpreter) -> Option<String> {
+pub fn ident_clone(ident: u32) -> u32 {
     Data::with(|d| {
-        let clone = d.ident[pop(interp)].clone();
-        interp.push(Value::I32(d.ident.push(clone)));
-        None
+        let clone = d.ident[ident].clone();
+        d.ident.push(clone)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn punct_clone(interp: &mut Interpreter) -> Option<String> {
+pub fn punct_clone(punct: u32) -> u32 {
     Data::with(|d| {
-        let clone = d.punct[pop(interp)].clone();
-        interp.push(Value::I32(d.punct.push(clone)));
-        None
+        let clone = d.punct[punct].clone();
+        d.punct.push(clone)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_clone(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_clone(literal: u32) -> u32 {
     Data::with(|d| {
-        let clone = d.literal[pop(interp)].clone();
-        interp.push(Value::I32(d.literal.push(clone)));
-        None
+        let clone = d.literal[literal].clone();
+        d.literal.push(clone)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_stream_iter_clone(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_iter_clone(iter: u32) -> u32 {
     Data::with(|d| {
-        let clone = d.intoiter[pop(interp)].clone();
-        interp.push(Value::I32(d.intoiter.push(clone)));
-        None
+        let clone = d.intoiter[iter].clone();
+        d.intoiter.push(clone)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_stream_to_string(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_to_string(stream: u32) -> u32 {
     Data::with(|d| {
-        let string = d.tokenstream[pop(interp)].to_string();
-        interp.push(Value::I32(d.string.push(string)));
-        None
+        let string = d.tokenstream[stream].to_string();
+        d.string.push(string)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn group_to_string(interp: &mut Interpreter) -> Option<String> {
+pub fn group_to_string(group: u32) -> u32 {
     Data::with(|d| {
-        let string = d.group[pop(interp)].to_string();
-        interp.push(Value::I32(d.string.push(string)));
-        None
+        let string = d.group[group].to_string();
+        d.string.push(string)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn ident_to_string(interp: &mut Interpreter) -> Option<String> {
+pub fn ident_to_string(ident: u32) -> u32 {
     Data::with(|d| {
-        let string = d.ident[pop(interp)].to_string();
-        interp.push(Value::I32(d.string.push(string)));
-        None
+        let string = d.ident[ident].to_string();
+        d.string.push(string)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn punct_to_string(interp: &mut Interpreter) -> Option<String> {
+pub fn punct_to_string(punct: u32) -> u32 {
     Data::with(|d| {
-        let string = d.punct[pop(interp)].to_string();
-        interp.push(Value::I32(d.string.push(string)));
-        None
+        let string = d.punct[punct].to_string();
+        d.string.push(string)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_to_string(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_to_string(literal: u32) -> u32 {
     Data::with(|d| {
-        let string = d.literal[pop(interp)].to_string();
-        interp.push(Value::I32(d.string.push(string)));
-        None
+        let string = d.literal[literal].to_string();
+        d.string.push(string)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn token_stream_debug(interp: &mut Interpreter) -> Option<String> {
+pub fn token_stream_debug(stream: u32) -> u32 {
     Data::with(|d| {
-        let debug = format!("{:?}", d.tokenstream[pop(interp)]);
-        interp.push(Value::I32(d.string.push(debug)));
-        None
+        let debug = format!("{:?}", d.tokenstream[stream]);
+        d.string.push(debug)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn group_debug(interp: &mut Interpreter) -> Option<String> {
+pub fn group_debug(group: u32) -> u32 {
     Data::with(|d| {
-        let debug = format!("{:?}", d.group[pop(interp)]);
-        interp.push(Value::I32(d.string.push(debug)));
-        None
+        let debug = format!("{:?}", d.group[group]);
+        d.string.push(debug)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn ident_debug(interp: &mut Interpreter) -> Option<String> {
+pub fn ident_debug(ident: u32) -> u32 {
     Data::with(|d| {
-        let debug = format!("{:?}", d.ident[pop(interp)]);
-        interp.push(Value::I32(d.string.push(debug)));
-        None
+        let debug = format!("{:?}", d.ident[ident]);
+        d.string.push(debug)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn punct_debug(interp: &mut Interpreter) -> Option<String> {
+pub fn punct_debug(punct: u32) -> u32 {
     Data::with(|d| {
-        let debug = format!("{:?}", d.punct[pop(interp)]);
-        interp.push(Value::I32(d.string.push(debug)));
-        None
+        let debug = format!("{:?}", d.punct[punct]);
+        d.string.push(debug)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn literal_debug(interp: &mut Interpreter) -> Option<String> {
+pub fn literal_debug(literal: u32) -> u32 {
     Data::with(|d| {
-        let debug = format!("{:?}", d.literal[pop(interp)]);
-        interp.push(Value::I32(d.string.push(debug)));
-        None
+        let debug = format!("{:?}", d.literal[literal]);
+        d.string.push(debug)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn span_debug(interp: &mut Interpreter) -> Option<String> {
+pub fn span_debug(span: u32) -> u32 {
     Data::with(|d| {
-        let debug = format!("{:?}", d.span[pop(interp)]);
-        interp.push(Value::I32(d.string.push(debug)));
-        None
+        let debug = format!("{:?}", d.span[span]);
+        d.string.push(debug)
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: [Int(I32)]
-pub fn watt_string_new(interp: &mut Interpreter) -> Option<String> {
+pub fn watt_string_new(memory: *mut [u8], ptr: u32, len: u32) -> u32 {
     Data::with(|d| {
-        let len = pop(interp) as usize;
-        let ptr = pop(interp) as usize;
-        let bytes = interp.get_memory_mut()[ptr..ptr + len].to_owned();
+        let len = len as usize;
+        let ptr = ptr as usize;
+        let bytes = unsafe { (*memory)[ptr..ptr + len].to_owned() };
         let string = String::from_utf8(bytes).expect("non-utf8");
-        interp.push(Value::I32(d.string.push(string)));
-        None
+        d.string.push(string)
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn watt_string_len(interp: &mut Interpreter) -> Option<String> {
+pub fn watt_string_len(string: u32) -> u32 {
     Data::with(|d| {
-        let string = &d.string[pop(interp)];
-        interp.push(Value::I32(string.len() as u32));
-        None
+        let string = &d.string[string];
+        string.len() as u32
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: []
-pub fn watt_string_read(interp: &mut Interpreter) -> Option<String> {
+pub fn watt_string_read(memory: *mut [u8], string: u32, ptr: u32) {
     Data::with(|d| {
-        let ptr = pop(interp) as usize;
-        let string = &d.string[pop(interp)];
-        interp.get_memory_mut()[ptr..ptr + string.len()].copy_from_slice(string.as_bytes());
-        None
+        let ptr = ptr as usize;
+        let string = &d.string[string];
+        unsafe {
+            (*memory)[ptr..ptr + string.len()].copy_from_slice(string.as_bytes());
+        }
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: [Int(I32)]
-pub fn watt_bytes_new(interp: &mut Interpreter) -> Option<String> {
+pub fn watt_bytes_new(memory: *mut [u8], ptr: u32, len: u32) -> u32 {
     Data::with(|d| {
-        let len = pop(interp) as usize;
-        let ptr = pop(interp) as usize;
-        let bytes = interp.get_memory_mut()[ptr..ptr + len].to_owned();
-        interp.push(Value::I32(d.bytes.push(bytes)));
-        None
+        let len = len as usize;
+        let ptr = ptr as usize;
+        let bytes = unsafe { (*memory)[ptr..ptr + len].to_owned() };
+        d.bytes.push(bytes)
     })
 }
 
-// args: [Int(I32)]
-// result: []
-pub fn watt_print_panic(interp: &mut Interpreter) -> Option<String> {
-    Data::with(|d| panic!("{}", d.string[pop(interp)]))
+pub fn watt_print_panic(string: u32) {
+    Data::with(|d| panic!("{}", d.string[string]))
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn watt_string_with_capacity(interp: &mut Interpreter) -> Option<String> {
+pub fn watt_string_with_capacity(cap: u32) -> u32 {
     Data::with(|d| {
-        let cap = pop(interp) as usize;
-        let string = d.string.push(String::with_capacity(cap));
-        interp.push(Value::I32(string));
-        None
+        let cap = cap as usize;
+        d.string.push(String::with_capacity(cap))
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: []
-pub fn watt_string_push_char(interp: &mut Interpreter) -> Option<String> {
+pub fn watt_string_push_char(string: u32, ch: u32) {
     Data::with(|d| {
-        let ch = pop(interp);
-        let string = &mut d.string[pop(interp)];
+        let ch = ch;
+        let string = &mut d.string[string];
         string.push(char::from_u32(ch).unwrap());
-        None
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: [Int(I32)]
-pub fn watt_string_char_at(interp: &mut Interpreter) -> Option<String> {
+pub fn watt_string_char_at(string: u32, pos: u32) -> u32 {
     Data::with(|d| {
-        let pos = pop(interp) as usize;
-        let string = &d.string[pop(interp)];
-        let ch = string[pos..].chars().next().unwrap() as u32;
-        interp.push(Value::I32(ch));
-        None
+        let pos = pos as usize;
+        let string = &d.string[string];
+        string[pos..].chars().next().unwrap() as u32
     })
 }
 
-// args: [Int(I32)]
-// result: [Int(I32)]
-pub fn watt_bytes_with_capacity(interp: &mut Interpreter) -> Option<String> {
+pub fn watt_bytes_with_capacity(cap: u32) -> u32 {
     Data::with(|d| {
-        let cap = pop(interp) as usize;
-        let string = d.bytes.push(Vec::with_capacity(cap));
-        interp.push(Value::I32(string));
-        None
+        let cap = cap as usize;
+        d.bytes.push(Vec::with_capacity(cap))
     })
 }
 
-// args: [Int(I32), Int(I32)]
-// result: []
-pub fn watt_bytes_push(interp: &mut Interpreter) -> Option<String> {
+pub fn watt_bytes_push(bytes: u32, b: u32) {
     Data::with(|d| {
-        let b = pop(interp) as u8;
-        let bytes = &mut d.bytes[pop(interp)];
+        let b = b as u8;
+        let bytes = &mut d.bytes[bytes];
         bytes.push(b);
-        None
     })
-}
-
-fn pop(interp: &mut Interpreter) -> u32 {
-    match interp.pop() {
-        Some(Value::I32(int)) => int,
-        _ => unreachable!("unexpected Value type on stack"),
-    }
-}
-
-fn pop64(interp: &mut Interpreter) -> u64 {
-    match interp.pop() {
-        Some(Value::I64(int)) => int,
-        _ => unreachable!("unexpected Value type on stack"),
-    }
-}
-
-fn popf(interp: &mut Interpreter) -> f32 {
-    match interp.pop() {
-        Some(Value::F32(float)) => float,
-        _ => unreachable!("unexpected Value type on stack"),
-    }
-}
-
-fn popf64(interp: &mut Interpreter) -> f64 {
-    match interp.pop() {
-        Some(Value::F64(float)) => float,
-        _ => unreachable!("unexpected Value type on stack"),
-    }
 }


### PR DESCRIPTION
This commit adds experimental support (aka off-by-default) to execute
wasm files in a precompiled release mode JIT exposed as a dynamic
library through the proposed wasm C API [1]. A build script determines
what's used, and for now it's only wired up to work on my own system. I
figured it'd be good to get this into CI though to test out and ensure
others can tinker around with this as well.

[1]: https://github.com/WebAssembly/wasm-c-api