### PR TITLE
Improve JIT build documentation and support

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,25 @@ fn main() {
 
 <br>
 
+## Enabling JIT compilation support
+
+Experimental support is available in `watt` to use a JIT at compile-time instead
+of a built-in interpreter. The JIT is expected to be a dynamic library which
+implements the [proposed wasm C API](https://github.com/webassembly/wasm-c-api).
+You can enable this usage by setting the environment variable:
+
+```
+$ export WATT_JIT=/path/to/libwasmtime_api.so
+```
+
+Note that the `WATT_JIT` must be set at build time when procedural macros are
+executing. And example library which implements the required API is
+[`wasmtime_api`](https://github.com/webassembly/wasm-c-api) which can be
+built with `cargo build --features wasm-c-api --release` inside the
+`wasmtime-api` folder of that repository.
+
+<br>
+
 ## Acknowledgements
 
 The current underlying Wasm runtime is a fork of the [Rust-WASM] project by

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,6 @@ fn main() {
     println!("cargo:rerun-if-env-changed=WATT_JIT");
 
     if std::env::var("WATT_JIT").is_ok() {
-        println!("cargo:rustc-link-search=native=/home/alex/code/wasmtime/target/release");
-        println!("cargo:rustc-link-lib=static=wasmtime_api");
         println!("cargo:rustc-cfg=jit");
     }
 }


### PR DESCRIPTION
Add a section to the README about how to use `WATT_JIT` as well as an
example of how to build wasmtime and use it. This also in the process
switches from static linkage to dynamic linkage discovered at runtime to
avoid having to deal with things like `LD_LIBRARY_PATH` with proc macros
(dylibs) depending on dylibs (wasmtime).