### PR TITLE
Optimize the wasm `proc-macro2` runtime

### DIFF
--- a/proc-macro/src/decode.rs
+++ b/proc-macro/src/decode.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::rc::Rc;
 use std::str;
 
 pub fn decode(mut buf: &[u8]) -> TokenStream {
@@ -36,7 +37,9 @@ impl Decode for TokenStream {
                 _ => tokens.push(TokenTree::Literal(Literal::decode(data))),
             }
         }
-        TokenStream { inner: tokens }
+        TokenStream {
+            inner: Rc::new(tokens),
+        }
     }
 }
 
@@ -114,7 +117,7 @@ impl Decode for Literal {
         Literal {
             span: Span::decode(data),
             kind: match byte(data) {
-                0 => LiteralKind::Local(str(data).to_string()),
+                0 => LiteralKind::Local(super::intern(str(data))),
                 _ => LiteralKind::Watt(handle::Literal(u32::decode(data))),
             },
         }


### PR DESCRIPTION
* Use an internal `Rc` inside of `TokenStream` to make clones cheap.
  Lazily fully clone the internal list of tokens if an `extend`
  happens.

* Use a simple interning scheme to ensure that `Ident` and `Literal` are
  also cheaply clone-able.

This overall ensures that every type is cheaply cloneable and should
help reduce extra allocations for types like `Ident`. Locally the
runtime for the "giant serde benchmark" improved by nearly 40%, dropping
the wasm execution time from 140ms to 80ms.

Closes #20