### PR TITLE
Change canonical entry point to use a separate static for &[u8]

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,14 @@ And in its src/lib.rs put:
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
+use watt::WasmMacro;
 
-static WASM: watt::Instance = watt::Instance::new(include_bytes!("my_macro.wasm"));
+static MACRO: WasmMacro = WasmMacro::new(WASM);
+static WASM: &[u8] = include_bytes("my_macro.wasm");
 
 #[proc_macro]
 pub fn my_macro(input: TokenStream) -> TokenStream {
-    WASM.proc_macro("my_macro", input)
+    MACRO.proc_macro("my_macro", input)
 }
 ```
 

--- a/demo/wa/src/lib.rs
+++ b/demo/wa/src/lib.rs
@@ -1,12 +1,14 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
+use watt::WasmMacro;
 
-static WASM: watt::Instance = watt::Instance::new(include_bytes! {
+static MACRO: WasmMacro = WasmMacro::new(WASM);
+static WASM: &[u8] = include_bytes! {
     "../../impl/target/wasm32-unknown-unknown/release/watt_demo.wasm"
-});
+};
 
 #[proc_macro_derive(Demo)]
 pub fn demo(input: TokenStream) -> TokenStream {
-    WASM.proc_macro_derive("demo", input)
+    MACRO.proc_macro_derive("demo", input)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,26 +208,28 @@ use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 ///
 /// ```
 /// # const IGNORE: &str = stringify! {
-/// static WASM: watt::Instance = watt::Instance::new(include_bytes!("my_macro.wasm"));
+/// static MACRO: WasmMacro = WasmMacro::new(WASM);
+/// static WASM: &[u8] = include_bytes!("my_macro.wasm");
 /// # };
 /// ```
-pub struct Instance {
+pub struct WasmMacro {
     wasm: &'static [u8],
     id: AtomicUsize,
 }
 
-impl Instance {
-    /// Creates a new `Instance` from the statically included blob of wasm bytes.
+impl WasmMacro {
+    /// Creates a new `WasmMacro` from the statically included blob of wasm bytes.
     ///
     /// # Examples
     ///
     /// ```
     /// # const IGNORE: &str = stringify! {
-    /// static WASM: watt::Instance = watt::Instance::new(include_bytes!("my_macro.wasm"));
+    /// static MACRO: WasmMacro = WasmMacro::new(WASM);
+    /// static WASM: &[u8] = include_bytes!("my_macro.wasm");
     /// # };
     /// ```
-    pub const fn new(wasm: &'static [u8]) -> Instance {
-        Instance {
+    pub const fn new(wasm: &'static [u8]) -> WasmMacro {
+        WasmMacro {
             wasm,
             id: AtomicUsize::new(0),
         }
@@ -255,8 +257,10 @@ impl Instance {
     /// extern crate proc_macro;
     ///
     /// use proc_macro::TokenStream;
+    /// use watt::WasmMacro;
     ///
-    /// static WASM: watt::Instance = watt::Instance::new(include_bytes!("my_macro.wasm"));
+    /// static MACRO: WasmMacro = WasmMacro::new(WASM);
+    /// static WASM: &[u8] = include_bytes!("my_macro.wasm");
     ///
     /// #[proc_macro]
     /// pub fn my_macro(input: TokenStream) -> TokenStream {
@@ -290,8 +294,10 @@ impl Instance {
     /// extern crate proc_macro;
     ///
     /// use proc_macro::TokenStream;
+    /// use watt::WasmMacro;
     ///
-    /// static WASM: watt::Instance = watt::Instance::new(include_bytes!("my_macro.wasm"));
+    /// static MACRO: WasmMacro = WasmMacro::new(WASM);
+    /// static WASM: &[u8] = include_bytes!("my_macro.wasm");
     ///
     /// #[proc_macro_derive(MyDerive)]
     /// pub fn my_macro(input: TokenStream) -> TokenStream {
@@ -325,8 +331,10 @@ impl Instance {
     /// extern crate proc_macro;
     ///
     /// use proc_macro::TokenStream;
+    /// use watt::WasmMacro;
     ///
-    /// static WASM: watt::Instance = watt::Instance::new(include_bytes!("my_macro.wasm"));
+    /// static MACRO: WasmMacro = WasmMacro::new(WASM);
+    /// static WASM: &[u8] = include_bytes!("my_macro.wasm");
     ///
     /// #[proc_macro_attribute]
     /// pub fn my_macro(args: TokenStream, input: TokenStream) -> TokenStream {


### PR DESCRIPTION
The previous entry point had too much going on for my taste:

```rust
static WASM: watt::Instance = watt::Instance::new(include_bytes!("my_macro.wasm"));
```

This commit replaces it with:

```rust
static MACRO: WasmMacro = WasmMacro::new(WASM);
static WASM: &[u8] = include_bytes("my_macro.wasm");
```