### PR TITLE
Lex TokenStreams from within wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,3 @@ include = [
 
 [workspace]
 members = ["demo/caller", "demo/wa", "runtime/tests", "proc-macro"]
-
-[patch.crates-io]
-watt = { path = "." }

--- a/demo/wa/Cargo.toml
+++ b/demo/wa/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 proc-macro = true
 
 [dependencies]
-watt = "0.2"
+watt = { path = "../.." }

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -11,3 +11,4 @@ default = ["proc-macro"]
 
 [dependencies]
 watt-abi = { path = "macros" }
+rustc_lexer = "0.1.0"

--- a/proc-macro/src/lexer.rs
+++ b/proc-macro/src/lexer.rs
@@ -1,0 +1,180 @@
+use std::iter;
+use std::mem;
+use std::rc::Rc;
+use std::vec;
+
+use crate::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
+use rustc_lexer::{first_token, TokenKind};
+
+fn tokenize(mut input: &str) -> impl Iterator<Item = (TokenKind, &str)> + '_ {
+    iter::from_fn(move || {
+        if input.is_empty() {
+            return None;
+        }
+
+        let token = first_token(input);
+        let text = &input[..token.len];
+        input = &input[token.len..];
+        Some((token.kind, text))
+    })
+}
+
+fn doc_attr(tts: &mut Vec<TokenTree>, doc: &str, inner: bool) {
+    tts.push(TokenTree::Punct(Punct::new('#', Spacing::Alone)));
+    if inner {
+        tts.push(TokenTree::Punct(Punct::new('!', Spacing::Alone)));
+    }
+    tts.push(TokenTree::Group(Group {
+        delimiter: Delimiter::Brace,
+        stream: TokenStream {
+            inner: Rc::new(vec![
+                TokenTree::Ident(Ident::new("doc", Span::call_site())),
+                TokenTree::Punct(Punct::new('=', Spacing::Alone)),
+                TokenTree::Literal(Literal::string(doc)),
+            ]),
+        },
+        span: Span::call_site(),
+    }))
+}
+
+pub fn lex(src: &str) -> Result<TokenStream, ()> {
+    let mut stack = Vec::new();
+    let mut active = Vec::new();
+
+    let mut iter = tokenize(src).peekable();
+    while let Some((kind, text)) = iter.next() {
+        match kind {
+            TokenKind::Whitespace => {}
+
+            TokenKind::LineComment => {
+                if text.starts_with("//!") {
+                    doc_attr(&mut active, &text[3..], true);
+                } else if text.starts_with("///") && !text.starts_with("////") {
+                    doc_attr(&mut active, &text[3..], false);
+                }
+            }
+            TokenKind::BlockComment { terminated: false } => return Err(()),
+            TokenKind::BlockComment { terminated: true } => {
+                // FIXME: This is wrong, but is good-enough for now. We don't
+                // appear to handle block doc-comments correctly in any fallback
+                // implementations, so this is about as correct as proc-macro2.
+                if text.starts_with("/*!") {
+                    doc_attr(&mut active, &text[3..text.len() - 2], true);
+                } else if text.starts_with("/**") {
+                    doc_attr(&mut active, &text[3..text.len() - 2], false);
+                }
+            }
+
+            TokenKind::OpenParen | TokenKind::OpenBrace | TokenKind::OpenBracket => {
+                let delimiter = match kind {
+                    TokenKind::OpenParen => Delimiter::Parenthesis,
+                    TokenKind::OpenBrace => Delimiter::Brace,
+                    TokenKind::OpenBracket => Delimiter::Bracket,
+                    _ => unreachable!(),
+                };
+                let parent = mem::replace(&mut active, Vec::new());
+                stack.push((delimiter, parent));
+            }
+
+            TokenKind::CloseParen | TokenKind::CloseBrace | TokenKind::CloseBracket => {
+                let expected = match kind {
+                    TokenKind::CloseParen => Delimiter::Parenthesis,
+                    TokenKind::CloseBrace => Delimiter::Brace,
+                    TokenKind::CloseBracket => Delimiter::Bracket,
+                    _ => unreachable!(),
+                };
+                let (delimiter, parent) = stack.pop().ok_or(())?;
+                if delimiter != expected {
+                    return Err(());
+                }
+
+                let body = mem::replace(&mut active, parent);
+                active.push(
+                    Group {
+                        delimiter,
+                        stream: TokenStream {
+                            inner: Rc::new(body),
+                        },
+                        span: Span::call_site(),
+                    }
+                    .into(),
+                );
+            }
+
+            TokenKind::Ident => {
+                active.push(Ident::new(text, Span::call_site()).into());
+            }
+            TokenKind::RawIdent => {
+                active.push(Ident::_new(&text[2..], true, Span::call_site()).into());
+            }
+            TokenKind::Literal { .. } => {
+                active.push(Literal::_new(text).into());
+            }
+            TokenKind::Lifetime { .. } => {
+                active.push(Punct::new('\'', Spacing::Joint).into());
+                active.push(Ident::new(&text[1..], Span::call_site()).into());
+            }
+
+            TokenKind::Semi
+            | TokenKind::Comma
+            | TokenKind::Dot
+            | TokenKind::At
+            | TokenKind::Pound
+            | TokenKind::Tilde
+            | TokenKind::Question
+            | TokenKind::Colon
+            | TokenKind::Dollar
+            | TokenKind::Eq
+            | TokenKind::Not
+            | TokenKind::Lt
+            | TokenKind::Gt
+            | TokenKind::Minus
+            | TokenKind::And
+            | TokenKind::Or
+            | TokenKind::Plus
+            | TokenKind::Star
+            | TokenKind::Slash
+            | TokenKind::Caret
+            | TokenKind::Percent => {
+                let peek = iter.peek().map(|t| t.0).unwrap_or(TokenKind::Unknown);
+                let spacing = match peek {
+                    TokenKind::Semi
+                    | TokenKind::Comma
+                    | TokenKind::Dot
+                    | TokenKind::At
+                    | TokenKind::Pound
+                    | TokenKind::Tilde
+                    | TokenKind::Question
+                    | TokenKind::Colon
+                    | TokenKind::Dollar
+                    | TokenKind::Eq
+                    | TokenKind::Not
+                    | TokenKind::Lt
+                    | TokenKind::Gt
+                    | TokenKind::Minus
+                    | TokenKind::And
+                    | TokenKind::Or
+                    | TokenKind::Plus
+                    | TokenKind::Star
+                    | TokenKind::Slash
+                    | TokenKind::Caret
+                    | TokenKind::Percent => Spacing::Joint,
+                    _ => Spacing::Alone,
+                };
+
+                let ch = text.chars().next().unwrap();
+                active.push(Punct::new(ch, spacing).into());
+            }
+
+            TokenKind::Unknown => return Err(()),
+        }
+    }
+
+    if !stack.is_empty() {
+        return Err(());
+    }
+
+    Ok(TokenStream {
+        inner: Rc::new(active),
+    })
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,6 +1,4 @@
-use proc_macro::{
-    token_stream, Group, Ident, LexError, Literal, Punct, Span, TokenStream, TokenTree,
-};
+use proc_macro::{Literal, Span, TokenStream};
 use std::cell::RefCell;
 use std::ops::{Index, IndexMut};
 
@@ -13,14 +11,8 @@ pub struct Data {
     pub string: Collection<String>,
     pub bytes: Collection<Vec<u8>>,
     pub tokenstream: Collection<TokenStream>,
-    pub tokentree: Collection<TokenTree>,
-    pub group: Collection<Group>,
-    pub ident: Collection<Ident>,
-    pub punct: Collection<Punct>,
     pub literal: Collection<Literal>,
     pub span: Collection<Span>,
-    pub intoiter: Collection<token_stream::IntoIter>,
-    pub lexerror: Collection<LexError>,
 }
 
 impl Data {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -30,17 +30,17 @@ fn str<'a>(bytes: &mut &'a [u8], data: &Data) -> &'a str {
 
 impl Decode for TokenStream {
     fn decode(bytes: &mut &[u8], data: &Data) -> Self {
-        let mut ret = TokenStream::new();
+        let mut tts = Vec::new();
         loop {
             match byte(bytes) {
                 0 => break,
-                1 => ret.extend(Some(TokenTree::Group(Group::decode(bytes, data)))),
-                2 => ret.extend(Some(TokenTree::Ident(Ident::decode(bytes, data)))),
-                3 => ret.extend(Some(TokenTree::Punct(Punct::decode(bytes, data)))),
-                _ => ret.extend(Some(TokenTree::Literal(Literal::decode(bytes, data)))),
+                1 => tts.push(TokenTree::Group(Group::decode(bytes, data))),
+                2 => tts.push(TokenTree::Ident(Ident::decode(bytes, data))),
+                3 => tts.push(TokenTree::Punct(Punct::decode(bytes, data))),
+                _ => tts.push(TokenTree::Literal(Literal::decode(bytes, data))),
             }
         }
-        ret
+        tts.into_iter().collect()
     }
 }
 


### PR DESCRIPTION
This is a draft PR to use `rustc_lexer` to handle the `FromStr` implementation for `TokenStream` entirely within wasm (#18). 

I'm pushing this up as a draft as I haven't run any tests on this implementation yet, nor have I benchmarked to see if it improves performance. Unfortunately I don't have a wa-serde-derive setup on my laptop right now, so it might be a bit before I get around to it.

In https://github.com/dtolnay/watt/issues/18#issue-515225393, it was suggested we could avoid parsing comments. I'm not sure that's possible, as macros can pass arbitrary strings into `from_str`, e.g. from a string literal, and we'd need to handle parsing them. If we decide not to support those callers some complexity could be eliminated by removing code related to doc comments.