### PR TITLE
Allow raw identifiers

### DIFF
--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -406,7 +406,11 @@ impl Ident {
     }
 
     pub fn new(string: &str, span: Span) -> Ident {
-        Ident::_new(string, false, span)
+        if string.starts_with("r#") {
+            Ident::_new(&string[2..], true, span)
+        } else {
+            Ident::_new(string, false, span)
+        }
     }
 
     pub fn span(&self) -> Span {


### PR DESCRIPTION
Fixes #33 

Tested with the same patch to the demo derive as in the issue, which now gives

```rust
message=Ok(Ident { sym: r#raw, span: Span { handle: 4, _marker: PhantomData } })
```