### PR TITLE
PoC: feature passthrough

### DIFF
--- a/demo/caller/Cargo.toml
+++ b/demo/caller/Cargo.toml
@@ -7,3 +7,7 @@ publish = false
 
 [dependencies]
 wa-demo = { path = "../wa" }
+
+[features]
+feat_a = ["wa-demo/feat_a"]
+feat_b = ["wa-demo/feat_b"]

--- a/demo/impl/src/lib.rs
+++ b/demo/impl/src/lib.rs
@@ -10,7 +10,14 @@ pub extern "C" fn demo(input: TokenStream) -> TokenStream {
     };
 
     let ident = input.ident;
-    let message = format!("Hello from WASM! My name is {}.", ident);
+    let mut message = format!("Hello from WASM! My name is {}.", ident);
+
+    if proc_macro2::features::check("feat_a") {
+        message.push_str(" feat_a is enabled.");
+    }
+    if proc_macro2::features::check("feat_b") {
+        message.push_str(" feat_b is enabled.");
+    }
 
     quote! {
         impl #ident {

--- a/demo/wa/Cargo.toml
+++ b/demo/wa/Cargo.toml
@@ -10,3 +10,7 @@ proc-macro = true
 
 [dependencies]
 watt = "0.3"
+
+[features]
+feat_a = []
+feat_b = []

--- a/demo/wa/src/lib.rs
+++ b/demo/wa/src/lib.rs
@@ -3,7 +3,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use watt::WasmMacro;
 
-static MACRO: WasmMacro = WasmMacro::new(WASM);
+static MACRO: WasmMacro = watt::wasm_macro_features!(WASM; "feat_a", "feat_b");
 static WASM: &[u8] = include_bytes! {
     "../../impl/target/wasm32-unknown-unknown/release/watt_demo.wasm"
 };

--- a/proc-macro/src/features.rs
+++ b/proc-macro/src/features.rs
@@ -1,0 +1,30 @@
+static mut ENABLED_FEATURES: Vec<u32> = Vec::new();
+
+#[no_mangle]
+#[doc(hidden)]
+//  FIXME: This is horribly unsafe (static mut) but should be ok because unthreaded wasm
+/// SAFETY: only call this when no other code in the wasm module is running
+pub unsafe extern "C" fn __watt_publish_feature(feature: u32) {
+    if let Err(i) = ENABLED_FEATURES.binary_search(&feature) {
+        ENABLED_FEATURES.insert(i, feature);
+    }
+}
+
+pub fn check(feature: &'static str) -> bool {
+    /// A simple 32 bit FNV hash function. Must be the same one as used on the proc-macro side.
+    ///
+    /// <https://en.wikipedia.org/wiki/Fowler–Noll–Vo_hash_function>
+    /// <http://www.isthe.com/chongo/tech/comp/fnv/index.html#FNV-1a>
+    fn fnv1a(bytes: &[u8]) -> u32 {
+        const FNV_OFFSET: u32 = 0x811C_9DC5;
+        const FNV_PRIME: u32 = 0x100_0193;
+        let mut hash = FNV_OFFSET;
+        for &byte in bytes {
+            hash ^= byte as u32;
+            hash = hash.wrapping_mul(FNV_PRIME);
+        }
+        hash
+    }
+    let feature_hash = fnv1a(feature.as_bytes());
+    unsafe { ENABLED_FEATURES.binary_search(&feature_hash).is_ok() }
+}

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -7,6 +7,9 @@ mod encode;
 mod ffi;
 mod rc;
 
+// FIXME: this is just hacked onto watt proc-macro shim because it's necessarily already in the wasm
+pub mod features;
+
 use crate::rc::Rc;
 use std::char;
 use std::cmp::Ordering;

--- a/src/features.rs
+++ b/src/features.rs
@@ -1,0 +1,11 @@
+#[macro_export]
+macro_rules! wasm_macro_features {
+    ($wasm:expr; $($feature:expr),* $(,)?) => {
+        $crate::WasmMacro::new_with_features(
+            $wasm,
+            &[$(
+                #[cfg(feature = $feature)] $feature,
+            )*]
+        )
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ mod runtime;
 mod data;
 mod decode;
 mod encode;
+mod features;
 mod import;
 mod sym;
 
@@ -218,6 +219,7 @@ use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 pub struct WasmMacro {
     wasm: &'static [u8],
     id: AtomicUsize,
+    features: &'static [&'static str],
 }
 
 impl WasmMacro {
@@ -232,8 +234,18 @@ impl WasmMacro {
     /// # };
     /// ```
     pub const fn new(wasm: &'static [u8]) -> WasmMacro {
+        const EMPTY: &[&str] = &[];
+        WasmMacro::new_with_features(wasm, EMPTY)
+    }
+
+    #[doc(hidden)]
+    pub const fn new_with_features(
+        wasm: &'static [u8],
+        features: &'static [&'static str],
+    ) -> WasmMacro {
         WasmMacro {
             wasm,
+            features,
             id: AtomicUsize::new(0),
         }
     }


### PR DESCRIPTION
Closes #35 

This is a very Proof of Concept execution of this feature. Notable limitations:

- only implemented for interpret and not jit
- does no checking to make sure that feature name hashes do not collide
- adds a new public function to the `proc_macro2` to be the wasm-side feature check
  - this should probably be a distinct crate used by the wasm-side implementation
  - thus the watt runtime should gracefully (ish: probably a nice panic message) error if the required symbol to publish features aren't there
- wasm-side implementation uses a `static mut` as opposed to a more principled shared global

But this implementation does work!

```rust
D:\repos\dtolnay\watt\demo\caller>cargo run --quiet --features=""
message=Hello from WASM! My name is S.

D:\repos\dtolnay\watt\demo\caller>cargo run --quiet --features="feat_a"
message=Hello from WASM! My name is S. feat_a is enabled.

D:\repos\dtolnay\watt\demo\caller>cargo run --quiet --features="feat_b"
message=Hello from WASM! My name is S. feat_b is enabled.

D:\repos\dtolnay\watt\demo\caller>cargo run --quiet --features="feat_a feat_b"
message=Hello from WASM! My name is S. feat_a is enabled. feat_b is enabled.
```

Simple overview of how the feature information flows into the wasm module:

- `WasmMacro` is created with `watt::wasm_macro_features!`. This takes the wasm binary to wrap as well as a list of feature strings.
- The wasm binary as well as a static array of the enabled features is passed to `WasmMacro::new_with_features`. This function, while necessarily public to be called by the macro, is hidden and not public API. This is so that the only named bits of information injected are the enabled (and opted-in) cargo features.
- `WasmMacro` just holds the list of features that it has been told are enabled.
- When the wasm module is instantiated, but before any other code is run, we call the `__watt_publish_feature` function of the wasm library with the FNV-1a hash of all enabled feature strings.
- `__watt_publish_feature` takes a single 32 bit integer as input and stores it in a `static mut` sorted vector of enabled feature hashes.
  - this is (most likely) sound because the location is only ever used mutably at module creation time.
- At macro time, the macro calls `proc_macro2::features::check("feature_name")`
- The feature name is turned into its FNV-1a hash again, and the feature list is checked for that hash.

While the details of an impl may change, the rough shape will stay the same:

- Collect a list of features to pass through
- Compress each feature to a primitive wasm ffi understands
- At module instantiation time, fire a message to the wasm for each feature
- At macro runtime, query a global populated with the enabled features

The [wasm interface types proposal](https://github.com/WebAssembly/interface-types/blob/master/proposals/interface-types/Explainer.md) could potentially allow passing an "abstract string" more simply, but for the time being, we have to compress the feature string into a 32 bit or 64 bit integer via some hash function.