### PR TITLE
Implement wasm=>host feature query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 travis-ci = { repository = "dtolnay/watt" }
 
 [workspace]
-members = ["demo/caller", "demo/wa", "runtime/tests", "proc-macro"]
+members = ["demo/caller", "demo/wa", "runtime/tests", "proc-macro", "watt-feature-passthrough"]
 
 [patch.crates-io]
 watt = { path = "." }

--- a/demo/caller/Cargo.toml
+++ b/demo/caller/Cargo.toml
@@ -7,3 +7,7 @@ publish = false
 
 [dependencies]
 wa-demo = { path = "../wa" }
+
+[features]
+feat_a = ["wa-demo/feat_a"]
+feat_b = ["wa-demo/feat_b"]

--- a/demo/impl/Cargo.toml
+++ b/demo/impl/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"
+watt-feature-passthrough = { path = "../../watt-feature-passthrough" }
 
 [workspace]
 

--- a/demo/impl/src/lib.rs
+++ b/demo/impl/src/lib.rs
@@ -1,6 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::DeriveInput;
+use watt_feature_passthrough::query_feature_flag;
 
 #[no_mangle]
 pub extern "C" fn demo(input: TokenStream) -> TokenStream {
@@ -10,7 +11,14 @@ pub extern "C" fn demo(input: TokenStream) -> TokenStream {
     };
 
     let ident = input.ident;
-    let message = format!("Hello from WASM! My name is {}.", ident);
+    let mut message = format!("Hello from WASM! My name is {}.", ident);
+
+    if query_feature_flag("feat_a").unwrap() {
+        message.push_str(" feat_a is enabled.");
+    }
+    if query_feature_flag("feat_b").unwrap() {
+        message.push_str(" feat_a is enabled.");
+    }
 
     quote! {
         impl #ident {

--- a/demo/wa/Cargo.toml
+++ b/demo/wa/Cargo.toml
@@ -10,3 +10,7 @@ proc-macro = true
 
 [dependencies]
 watt = "0.3"
+
+[features]
+feat_a = []
+feat_b = []

--- a/demo/wa/src/lib.rs
+++ b/demo/wa/src/lib.rs
@@ -3,7 +3,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use watt::WasmMacro;
 
-static MACRO: WasmMacro = WasmMacro::new(WASM);
+static MACRO: WasmMacro = WasmMacro!(WASM, "feat_a", "feat_b");
 static WASM: &[u8] = include_bytes! {
     "../../impl/target/wasm32-unknown-unknown/release/watt_demo.wasm"
 };

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,6 +1,7 @@
 use proc_macro::{Literal, Span, TokenStream};
 use std::cell::RefCell;
 use std::ops::{Index, IndexMut};
+use std::collections::BTreeMap;
 
 thread_local! {
     static DATA: RefCell<Data> = RefCell::new(Data::default());
@@ -13,6 +14,7 @@ pub struct Data {
     pub tokenstream: Collection<TokenStream>,
     pub literal: Collection<Literal>,
     pub span: Collection<Span>,
+    pub flags: BTreeMap<&'static str, bool>,
 }
 
 impl Data {

--- a/src/import.rs
+++ b/src/import.rs
@@ -8,6 +8,8 @@ pub fn host_func(name: &str, store: &Store) -> HostFunc {
         "token_stream_parse" => mem_func2(sym::token_stream_parse, store),
         "literal_to_string" => func1(sym::literal_to_string, store),
 
+        "query_feature_flag" => mem_func2(sym::query_feature_flag, store),
+
         "string_new" => mem_func2(sym::string_new, store),
         "string_len" => func1(sym::string_len, store),
         "string_read" => mem_func2(sym::string_read, store),

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -46,7 +46,7 @@ impl ThreadState {
 pub fn proc_macro(fun: &str, inputs: Vec<TokenStream>, instance: &WasmMacro) -> TokenStream {
     STATE.with(|state| {
         let state = &mut state.borrow_mut();
-        let flags = instance.flags().iter().copied().collect();
+        let flags = instance.flags().iter().cloned().collect();
         let instance = state.instance(instance);
         let exports = Exports::collect(instance, fun);
 

--- a/src/interpret.rs
+++ b/src/interpret.rs
@@ -46,11 +46,13 @@ impl ThreadState {
 pub fn proc_macro(fun: &str, inputs: Vec<TokenStream>, instance: &WasmMacro) -> TokenStream {
     STATE.with(|state| {
         let state = &mut state.borrow_mut();
+        let flags = instance.flags().iter().copied().collect();
         let instance = state.instance(instance);
         let exports = Exports::collect(instance, fun);
 
         let _guard = Data::guard();
         let raws: Vec<Value> = Data::with(|d| {
+            d.flags = flags;
             inputs
                 .into_iter()
                 .map(|input| Value::I32(d.tokenstream.push(input)))

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -49,12 +49,14 @@ impl ThreadState {
 pub fn proc_macro(fun: &str, inputs: Vec<TokenStream>, instance: &WasmMacro) -> TokenStream {
     STATE.with(|state| {
         let mut state = state.borrow_mut();
+        let flags = instance.flags().iter().copied().collect();
         let (module, instance) = state.instance(instance);
         let instance_exports = instance.exports();
         let exports = Exports::collect(module, &instance_exports, fun);
 
         let _guard = Data::guard();
         let raws = Data::with(|d| {
+            d.flags = flags;
             inputs
                 .into_iter()
                 .map(|input| Val::i32(d.tokenstream.push(input) as i32))

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -49,7 +49,7 @@ impl ThreadState {
 pub fn proc_macro(fun: &str, inputs: Vec<TokenStream>, instance: &WasmMacro) -> TokenStream {
     STATE.with(|state| {
         let mut state = state.borrow_mut();
-        let flags = instance.flags().iter().copied().collect();
+        let flags = instance.flags().iter().cloned().collect();
         let (module, instance) = state.instance(instance);
         let instance_exports = instance.exports();
         let exports = Exports::collect(module, &instance_exports, fun);

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -1,6 +1,20 @@
 use crate::data::Data;
 use std::str;
 
+pub fn query_feature_flag(memory: &mut [u8], ptr: u32, len: u32) -> u32 {
+    Data::with(|d| {
+        let len = len as usize;
+        let ptr = ptr as usize;
+        let bytes = &memory[ptr..ptr + len];
+        let string = str::from_utf8(bytes).expect("non-utf8");
+        match d.flags.get(string) {
+            Some(&false) => 0,
+            Some(&true) => 1,
+            None => (-1i32) as u32,
+        }
+    })
+}
+
 pub fn literal_to_string(literal: u32) -> u32 {
     Data::with(|d| {
         let string = d.literal[literal].to_string();

--- a/watt-feature-passthrough/Cargo.toml
+++ b/watt-feature-passthrough/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "watt-feature-passthrough"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+authors = ["Christopher Durham (CAD97) <cad97@cad97.com>"]
+
+[dependencies]

--- a/watt-feature-passthrough/src/lib.rs
+++ b/watt-feature-passthrough/src/lib.rs
@@ -1,0 +1,14 @@
+#[link(wasm_import_module = "watt-0.3")]
+extern "C" {
+    #[link_name = "query_feature_flag"]
+    fn query_feature_flag_raw(ptr: *const u8, len: u32) -> u32;
+}
+
+pub fn query_feature_flag(flag: &str) -> Option<bool> {
+    let res = unsafe { query_feature_flag_raw(flag.as_bytes().as_ptr(), flag.len() as u32) };
+    match res {
+        0 => Some(false),
+        1 => Some(true),
+        _ => None,
+    }
+}


### PR DESCRIPTION
Supersedes #36, closes #35 

This implements a call from the wasm to the host runtime that queries for a given feature string, returning `0` for a feature that has been shared as `false`, `1` for `true`, and any other value (`-1`) for a flag that has not been shared to the wasm.

Rather than bolting this onto `proc_macro2` like was done in the PoC #36, I've created a new micro-crate to link just this functionality, that the macro can use as a path dependency (as is patched for `proc_macro2` as well).

For testing/not-in-watt use, the crate should probably only link the watt impl under a feature flag, and just always return `Some(true)`.