### PR TITLE
Update to support proc-macro2 1.0.26

### DIFF
--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -55,6 +55,12 @@ pub struct LexError {
     _marker: PhantomData<Rc<()>>,
 }
 
+impl LexError {
+    pub fn span(&self) -> Span {
+        Span::call_site()
+    }
+}
+
 impl TokenStream {
     pub fn new() -> Self {
         TokenStream {


### PR DESCRIPTION
Fixes a build error in syn due to a reliance on a new API from proc-macro2.
https://github.com/alexcrichton/proc-macro2/releases/tag/1.0.26

```console
error[E0599]: no method named `span` found for struct `LexError` in the current scope
   --> .cargo/registry/src/github.com-1ecc6299db9ec823/syn-1.0.68/src/error.rs:352:24
    |
352 |         Error::new(err.span(), "lex error")
    |                        ^^^^ method not found in `LexError`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
note: `spanned::Spanned` defines an item `span`, perhaps you need to implement it
   --> .cargo/registry/src/github.com-1ecc6299db9ec823/syn-1.0.68/src/spanned.rs:102:1
    |
102 | pub trait Spanned {
    | ^^^^^^^^^^^^^^^^^
```