### PR TITLE
Fix the WATT_JIT feature

### DIFF
--- a/jit/src/ffi.rs
+++ b/jit/src/ffi.rs
@@ -15,8 +15,8 @@ pub type wasm_message_t = wasm_name_t;
 pub type wasm_func_callback_with_env_t = Option<
     unsafe extern "C" fn(
         env: *mut c_void,
-        args: *const wasm_val_t,
-        results: *mut wasm_val_t,
+        args: *const wasm_val_vec_t,
+        results: *mut wasm_val_vec_t,
     ) -> *mut wasm_trap_t,
 >;
 //pub type wasm_table_size_t = u32;
@@ -91,11 +91,11 @@ pub struct wasm_instance_t {
 //pub struct wasm_frame_t {
 //    _unused: [u8; 0],
 //}
-//#[repr(C)]
-//pub struct wasm_val_vec_t {
-//    pub size: usize,
-//    pub data: *mut wasm_val_t,
-//}
+#[repr(C)]
+pub struct wasm_val_vec_t {
+    pub size: usize,
+    pub data: *mut wasm_val_t,
+}
 #[repr(C)]
 pub struct wasm_val_t {
     pub kind: wasm_valkind_t,
@@ -599,8 +599,8 @@ extern_apis! {
     pub fn wasm_func_result_arity(arg1: *const wasm_func_t) -> usize;
     pub fn wasm_func_call(
         arg1: *const wasm_func_t,
-        args: *const wasm_val_t,
-        results: *mut wasm_val_t,
+        args: *const wasm_val_vec_t,
+        results: *mut wasm_val_vec_t,
     ) -> *mut wasm_trap_t;
     //pub fn wasm_global_delete(arg1: *mut wasm_global_t);
     //pub fn wasm_global_copy(arg1: *const wasm_global_t) -> *mut wasm_global_t;
@@ -737,7 +737,7 @@ extern_apis! {
     pub fn wasm_instance_new(
         arg1: *mut wasm_store_t,
         arg2: *const wasm_module_t,
-        imports: *const *const wasm_extern_t,
+        imports: *const wasm_extern_vec_t,
         arg3: *mut *mut wasm_trap_t,
     ) -> *mut wasm_instance_t;
     pub fn wasm_instance_exports(arg1: *const wasm_instance_t, out: *mut wasm_extern_vec_t);

--- a/jit/src/valtype.rs
+++ b/jit/src/valtype.rs
@@ -34,7 +34,7 @@ pub struct ValTypeVec {
 }
 
 impl ValTypeVec {
-    pub fn new(list: &[ValType]) -> ValTypeVec {
+    pub fn new(mut list: Vec<ValType>) -> ValTypeVec {
         unsafe {
             let mut raw = mem::zeroed();
             ffi::wasm_valtype_vec_new(
@@ -42,6 +42,7 @@ impl ValTypeVec {
                 list.len(),
                 list.as_ptr() as *const *mut ffi::wasm_valtype_t,
             );
+            list.set_len(0);
             ValTypeVec { raw }
         }
     }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -125,7 +125,7 @@ fn call(func: &FuncRef, args: &[Val]) -> Val {
 }
 
 fn extern_vals(module: &Module, store: &mut Store) -> InstanceImports {
-    let mut imports = InstanceImports::default();
+    let mut imports = InstanceImports::with_capacity(module.imports().len());
     for import in module.imports().iter() {
         imports.func(mk_host_func(import, store));
     }


### PR DESCRIPTION
I was curious to see the impact of Wasmtime's recent development since I
last added the `WATT_JIT` env var feature to `watt` a few years ago
since quite a lot has changed about Wasmtime in the meantime. The
changes in this PR account for some ABI changes which have happened in
the C API which doesn't account for anything major.

Taking my old benchmark of `#[derive(Serialize)]` on
`struct S(f32, ...  /* 1000 times */)` the timings I get for the latest
version of `serde_derive` are:

|         | native | watt  | watt (cached) |
|---------|--------|-------|---------------|
| debug   | 156ms  | 280ms | 125ms         |
| release |  70ms  | 257ms | 100ms         |

Using instead `#[derive(Serialize)] struct S(f32)` the timings I get are:

|         | native | watt  | watt (cached) |
|---------|--------|-------|---------------|
| debug   |  1ms   | 241ms | 41ms          |
| release |  387us | 205ms | 46ms          |

So for large inputs jit-compiled WebAssembly can be faster than the
native `serde_derive` when serde is itself compiled in debug mode. Note
that this is almost always the default nowadays since `cargo build
--release` will currently build build-dependencies with no
optimizations. Only through explicit profile configuration can
`serde_derive` be built in optimized mode (as I did to collect the
above numbers).

The `watt (cached)` column is where I enabled Wasmtime's global
compilation cache to avoid recompiling the module every time the
proc-macro is loaded which is why the timings are much lower. The
difference between `watt` and `watt (cached)` is the compile time of the
module itself. The 40ms or so in `watt (cached)` is almost entirely
overhead of loading the module from cache which involves decompressing
the module from disk and additionally sloshing bytes around. More
efficient storage mediums exist for Wasmtime modules which means that it
would actually be pretty easy to shave off a good chunk of time from
that. Additionally Wasmtime has a custom C API which significantly
differs from the one used in this repository which would also be
significantly faster for calling into the host from wasm. Of the current
~3ms runtime in wasm itself that could probably be reduced further with
more optimized calls.

Overall this seems like pretty good progress made on Wasmtime in the
interim since all my initial work in #2. In any case I wanted to post
this to get the `WATT_JIT` feature at least working again since
otherwise it's segfaulting right now, and perhaps in the future if
necessary more perf work can be done!