### PR TITLE
Stabilize Ident::new_raw in proc-macro

### DIFF
--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -415,7 +415,7 @@ impl Ident {
         Ident::_new(string, false, span)
     }
 
-    pub(crate) fn new_raw(string: &str, span: Span) -> Ident {
+    pub fn new_raw(string: &str, span: Span) -> Ident {
         Ident::_new(string, true, span)
     }
 


### PR DESCRIPTION
This was stabilized in libproc_macro in Rust 1.47.0.