### PR TITLE
Turn on deny(unsafe_op_in_unsafe_fn)

### DIFF
--- a/jit/src/ffi.rs
+++ b/jit/src/ffi.rs
@@ -277,10 +277,12 @@ macro_rules! extern_apis {
         pub unsafe extern "C" fn $name($($arg: $ty),*) $(-> $ret)? {
             static PTR: AtomicUsize = AtomicUsize::new(0);
             let _fnptr = resolve(&PTR, concat!(stringify!($name), "\0"));
-            mem::transmute::<
-                usize,
-                unsafe extern "C" fn($($ty),*) $( -> $ret)?
-            >(_fnptr)($($arg),*)
+            unsafe {
+                mem::transmute::<
+                    usize,
+                    unsafe extern "C" fn($($ty),*) $( -> $ret)?
+                >(_fnptr)($($arg),*)
+            }
         }
     )*);
 }

--- a/jit/src/lib.rs
+++ b/jit/src/lib.rs
@@ -43,7 +43,7 @@ pub use self::val::Val;
 pub use self::valtype::{ValType, ValTypeVec};
 
 unsafe fn name_to_str<'a>(name: *const ffi::wasm_name_t) -> &'a str {
-    str::from_utf8_unchecked(slice::from_raw_parts((*name).data, (*name).size))
+    unsafe { str::from_utf8_unchecked(slice::from_raw_parts((*name).data, (*name).size)) }
 }
 
 pub mod current_memory {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@
 //! [Rust-WASM]: https://github.com/yblein/rust-wasm
 
 #![doc(html_root_url = "https://docs.rs/watt/0.5.0")]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,


### PR DESCRIPTION
This is allow-by-default for now in 2021 edition, but will become warn-by-default in 2024 edition.