### PR TITLE
Fix for recent syn version

### DIFF
--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -25,6 +25,7 @@ use crate::rc::Rc;
 use std::char;
 use std::cmp::Ordering;
 use std::collections::HashSet;
+use std::ffi::CStr;
 use std::fmt::{self, Debug, Display, Write as _};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
@@ -675,6 +676,25 @@ impl Literal {
         for b in bytes {
             match *b {
                 b'\0' => escaped.push_str(r"\0"),
+                b'\t' => escaped.push_str(r"\t"),
+                b'\n' => escaped.push_str(r"\n"),
+                b'\r' => escaped.push_str(r"\r"),
+                b'"' => escaped.push_str("\\\""),
+                b'\\' => escaped.push_str("\\\\"),
+                b'\x20'..=b'\x7E' => escaped.push(*b as char),
+                _ => {
+                    let _ = write!(escaped, "\\x{:02X}", b);
+                }
+            }
+        }
+        escaped.push('"');
+        Literal::_new(escaped)
+    }
+
+    pub fn c_string(cstr: &CStr) -> Self {
+        let mut escaped = "c\"".to_string();
+        for b in cstr.to_bytes() {
+            match *b {
                 b'\t' => escaped.push_str(r"\t"),
                 b'\n' => escaped.push_str(r"\n"),
                 b'\r' => escaped.push_str(r"\r"),

--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -186,6 +186,12 @@ impl Debug for TokenStream {
     }
 }
 
+impl Display for LexError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("cannot parse string into token stream")
+    }
+}
+
 impl Debug for LexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("LexError")


### PR DESCRIPTION
This adds two missing methods/impls to build recent syn version.

> ```
> error[E0277]: `LexError` doesn't implement `std::fmt::Display`
>   --> /home/mwanzenboeck/.cargo/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.86/src/error.rs:407:32
>     |
> 407 |         Error::new(err.span(), err)
>     |         ----------             ^^^ `LexError` cannot be formatted with the default formatter
>     |         |
>     |         required by a bound introduced by this call
>     |
>     = help: the trait `std::fmt::Display` is not implemented for `LexError`
>     = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
> note: required by a bound in `error::Error::new`
>    --> /home/mwanzenboeck/.cargo/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.86/src/error.rs:158:19
>     |
> 158 |     pub fn new<T: Display>(span: Span, message: T) -> Self {
>     |                   ^^^^^^^ required by this bound in `Error::new`
> 
> error[E0599]: no function or associated item named `c_string` found for struct `proc_macro2::Literal` in the current scope
>    --> /home/mwanzenboeck/.cargo/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.86/src/lit.rs:310:34
>     |
> 310 |         let mut token = Literal::c_string(value);
>     |                                  ^^^^^^^^ function or associated item not found in `Literal`
>     |
