### PR TITLE
add byte_character method to proc-macro

### DIFF
--- a/proc-macro/src/lib.rs
+++ b/proc-macro/src/lib.rs
@@ -676,6 +676,27 @@ impl Literal {
         Literal::_new(repr)
     }
 
+    /// Creates a byte character literal.
+    /// Added in Rust 1.79.
+    #[allow(clippy::match_overlapping_arm)]
+    pub fn byte_character(byte: u8) -> Self {
+        let mut repr = "b'".to_string();
+        match byte {
+            b'\0' => repr.push_str(r"\0"),
+            b'\t' => repr.push_str(r"\t"),
+            b'\n' => repr.push_str(r"\n"),
+            b'\r' => repr.push_str(r"\r"),
+            b'\'' => repr.push_str(r"\'"),
+            b'\\' => repr.push_str(r"\\"),
+            b'\x20'..=b'\x7E' => repr.push(byte as char),
+            _ => {
+                let _ = write!(repr, r"\x{:02X}", byte);
+            }
+        }
+        repr.push('\'');
+        Literal::_new(repr)
+    }
+
     #[allow(clippy::match_overlapping_arm)]
     pub fn byte_string(bytes: &[u8]) -> Self {
         let mut escaped = "b\"".to_string();


### PR DESCRIPTION
[byte_character](https://docs.rs/proc-macro2/1.0.105/proc_macro2/struct.Literal.html#method.byte_character) in proc_macro2 hasn't been added this fork yet.
As of [this pr](https://github.com/dtolnay/syn/pull/1951), `syn` makes use of this method.

Attempting to use watt with this version of `syn` produces compilation errors, so I snagged the upstream implementation [here](https://github.com/dtolnay/proc-macro2/blob/master/src/fallback.rs#L1062), which fixes. 